### PR TITLE
fix: replace bpmct/coder-nixos references with coder/box

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Two community tools do the heavy lifting:
 From a NixOS live USB on the target box, with network access (any reasonably recent ISO from [nixos.org](https://nixos.org/download/) works; the installed system pins its own nixpkgs in `flake.lock` independent of what the USB is running):
 
 ```sh
-nix-shell -p git --run "git clone https://github.com/bpmct/coder-nixos /tmp/coder-nixos"
-cd /tmp/coder-nixos
+nix-shell -p git --run "git clone https://github.com/coder/box /tmp/box"
+cd /tmp/box
 sudo ./nixos/install.sh
 ```
 

--- a/coderd/templates/k3s-podman/README.md
+++ b/coderd/templates/k3s-podman/README.md
@@ -2,7 +2,7 @@
 display_name: Kubernetes + Podman (Docker-compatible socket)
 description: Workspace pods share the host's rootless Podman socket — no privileged mode, no daemon.
 icon: /icon/docker.svg
-maintainer_github: bpmct
+maintainer_github: coder
 verified: false
 tags: [kubernetes, docker, podman, k3s]
 ---

--- a/coderd/templates/k3s-sysbox/README.md
+++ b/coderd/templates/k3s-sysbox/README.md
@@ -2,7 +2,7 @@
 display_name: Kubernetes + Sysbox (Docker-in-Workspace)
 description: Full Docker-in-workspace via sysbox-runc — no privileged mode required.
 icon: /icon/docker.svg
-maintainer_github: bpmct
+maintainer_github: coder
 verified: false
 tags: [kubernetes, docker, sysbox, k3s]
 ---

--- a/nixos/install.sh
+++ b/nixos/install.sh
@@ -6,8 +6,8 @@
 #
 # Usage from a NixOS live USB:
 #
-#   nix-shell -p git --run "git clone https://github.com/bpmct/coder-nixos /tmp/coder-nixos"
-#   cd /tmp/coder-nixos
+#   nix-shell -p git --run "git clone https://github.com/coder/box /tmp/box"
+#   cd /tmp/box
 #   sudo ./nixos/install.sh                  # interactive disk picker, defaults for the rest
 #   sudo ./nixos/install.sh --disk /dev/sda --yes
 #


### PR DESCRIPTION
## Summary

Replaces all GitHub repo references to `bpmct/coder-nixos` with `coder/box`, as requested in #6.

## Changes

- **`nixos/install.sh`** — updated the clone URL in the usage comment to `https://github.com/coder/box` and the clone target directory to `/tmp/box`.
- **`README.md`** — same clone URL + directory update in the install instructions.
- **`coderd/templates/k3s-podman/README.md`** and **`coderd/templates/k3s-sysbox/README.md`** — set `maintainer_github: coder`.

## Verification

- `git grep "bpmct/coder-nixos"` / `maintainer_github: bpmct` returns no matches.
- `bash -n nixos/install.sh` passes (comment-only change in the script).

Closes #6