### PR TITLE
fix(k3s): order coder.service after coder-k3s-namespace

### DIFF
--- a/nixos/k3s-podman.nix
+++ b/nixos/k3s-podman.nix
@@ -188,16 +188,9 @@ in
     };
 
     # ── Inject KUBECONFIG into coder.service ──────────────────────────────────
-    # Merges into the existing coder.service environment block (set in
-    # configuration.nix) so Terraform's kubernetes provider picks it up.
-    # lib.mkMerge ensures both the base environment and this addition are applied.
-    #
-    # Also order coder.service AFTER coder-k3s-namespace.service so the
-    # coder-workspaces namespace exists before Coder runs its first
-    # template-sync / workspace build. Without this, on a cold boot Coder can
-    # start provisioning before coder-k3s-namespace has run, and the build
-    # fails with `namespaces "coder-workspaces" not found` (the namespace is
-    # created seconds later, leaving the workspace stuck in a failed state).
+    # Inject KUBECONFIG for Terraform's kubernetes provider, and order after
+    # coder-k3s-namespace so the coder-workspaces namespace exists before
+    # Coder's first workspace build (else it fails: namespace not found).
     systemd.services.coder = {
       after    = [ "coder-k3s-namespace.service" ];
       requires = [ "coder-k3s-namespace.service" ];

--- a/nixos/k3s-podman.nix
+++ b/nixos/k3s-podman.nix
@@ -191,7 +191,16 @@ in
     # Merges into the existing coder.service environment block (set in
     # configuration.nix) so Terraform's kubernetes provider picks it up.
     # lib.mkMerge ensures both the base environment and this addition are applied.
+    #
+    # Also order coder.service AFTER coder-k3s-namespace.service so the
+    # coder-workspaces namespace exists before Coder runs its first
+    # template-sync / workspace build. Without this, on a cold boot Coder can
+    # start provisioning before coder-k3s-namespace has run, and the build
+    # fails with `namespaces "coder-workspaces" not found` (the namespace is
+    # created seconds later, leaving the workspace stuck in a failed state).
     systemd.services.coder = {
+      after    = [ "coder-k3s-namespace.service" ];
+      requires = [ "coder-k3s-namespace.service" ];
       environment = {
         KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
       };

--- a/nixos/k3s-sysbox.nix
+++ b/nixos/k3s-sysbox.nix
@@ -348,7 +348,16 @@ in
     environment.variables.KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
 
     # ── Inject KUBECONFIG into coder.service ─────────────────────────────
+    #
+    # Also order coder.service AFTER coder-k3s-namespace.service so the
+    # coder-workspaces namespace exists before Coder runs its first
+    # template-sync / workspace build. Without this, on a cold boot Coder can
+    # start provisioning before coder-k3s-namespace has run, and the build
+    # fails with `namespaces "coder-workspaces" not found` (the namespace is
+    # created seconds later, leaving the workspace stuck in a failed state).
     systemd.services.coder = {
+      after    = [ "coder-k3s-namespace.service" ];
+      requires = [ "coder-k3s-namespace.service" ];
       environment = {
         KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
       };

--- a/nixos/k3s-sysbox.nix
+++ b/nixos/k3s-sysbox.nix
@@ -348,13 +348,9 @@ in
     environment.variables.KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
 
     # ── Inject KUBECONFIG into coder.service ─────────────────────────────
-    #
-    # Also order coder.service AFTER coder-k3s-namespace.service so the
-    # coder-workspaces namespace exists before Coder runs its first
-    # template-sync / workspace build. Without this, on a cold boot Coder can
-    # start provisioning before coder-k3s-namespace has run, and the build
-    # fails with `namespaces "coder-workspaces" not found` (the namespace is
-    # created seconds later, leaving the workspace stuck in a failed state).
+    # Inject KUBECONFIG for Terraform's kubernetes provider, and order after
+    # coder-k3s-namespace so the coder-workspaces namespace exists before
+    # Coder's first workspace build (else it fails: namespace not found).
     systemd.services.coder = {
       after    = [ "coder-k3s-namespace.service" ];
       requires = [ "coder-k3s-namespace.service" ];


### PR DESCRIPTION
On a cold boot, Coder could start provisioning before the `coder-k3s-namespace` oneshot had created the `coder-workspaces` namespace, so the first workspace build failed with:

```
Error: namespaces "coder-workspaces" not found
```

The namespace then appeared seconds later (the oneshot is only `wantedBy = multi-user.target`, with no ordering vs. `coder.service`), leaving the workspace stuck in a failed state until a manual rebuild/retry.

Observed live on a box: a `k3s-podman` workspace build failed at `20:20:33`; `coder-workspaces` was created at `20:21:08` — 35 s too late. Re-running the build then succeeded with no other change.

## Fix

Add to the `systemd.services.coder` overlay in **both** `nixos/k3s-podman.nix` and `nixos/k3s-sysbox.nix`:

```nix
after    = [ "coder-k3s-namespace.service" ];
requires = [ "coder-k3s-namespace.service" ];
```

`coder-k3s-namespace` already orders itself after k3s + the kubeconfig fix, so this guarantees the namespace exists before Coder runs its first `coder-init-admin` template deploy / workspace build.

## Validation

- `nixos-rebuild dry-build --flake /etc/nixos-repo` — evaluates clean.