### PR TITLE
fix: never suspend the appliance

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -107,24 +107,19 @@ in
 
     # ── Never suspend ───────────────────────────────────────────────
     # The box is an always-on appliance (Coder server + k3s) reached over the
-    # LAN/tunnel; it must never go to sleep. A suspend drops the NIC, so the
-    # machine silently falls off the network (no mDNS, no SSH, tunnel dies)
-    # until someone physically wakes it. The shipped image runs a KDE desktop,
-    # which exposes a "Sleep" action and reacts to the power key, and a stray
-    # `systemctl suspend` / Suspend() D-Bus call would do the same. Mask all
-    # sleep targets so every one of those paths becomes a no-op, and tell
-    # logind to ignore idle. This is hardening, not a fix for a specific
-    # trigger — an appliance simply should not be suspendable.
-    systemd.targets.sleep.enable       = false;
-    systemd.targets.suspend.enable     = false;
-    systemd.targets.hibernate.enable   = false;
-    systemd.targets.hybrid-sleep.enable = false;
-    services.logind.settings.Login = {
-      HandlePowerKey  = "ignore";
-      HandleSuspendKey = "ignore";
-      HandleLidSwitch = "ignore";
-      IdleAction      = "ignore";
-    };
+    # LAN and a *.try.coder.app tunnel. A suspend drops the NIC, so the machine
+    # silently falls off the network (no mDNS, no SSH, tunnel dies) until
+    # someone physically wakes it. The shipped image runs a KDE desktop, which
+    # exposes a "Sleep" action, and a stray `systemctl suspend` / Suspend()
+    # D-Bus call would do the same. Mask the suspend target so all of those
+    # paths become a no-op.
+    #
+    # Scope is deliberately narrow: only suspend is blocked. Hibernate/
+    # hybrid-sleep and idle/lid/power-key handling are left at their defaults —
+    # the only thing we care about is the box not suspending itself off the
+    # network.
+    systemd.targets.suspend.enable = false;
+    services.logind.settings.Login.HandleSuspendKey = "ignore";
 
     # ── Networking ────────────────────────────────────────────────────────────
     # Central default hostname. Install hosts override this: flake.nix's mkHost

--- a/configuration.nix
+++ b/configuration.nix
@@ -105,6 +105,27 @@ in
     # compressed in-RAM swap device instead, sized to half of RAM.
     zramSwap.enable = lib.mkDefault true;
 
+    # ── Never suspend ───────────────────────────────────────────────
+    # The box is an always-on appliance (Coder server + k3s) reached over the
+    # LAN/tunnel; it must never go to sleep. A suspend drops the NIC, so the
+    # machine silently falls off the network (no mDNS, no SSH, tunnel dies)
+    # until someone physically wakes it. The shipped image runs a KDE desktop,
+    # which exposes a "Sleep" action and reacts to the power key, and a stray
+    # `systemctl suspend` / Suspend() D-Bus call would do the same. Mask all
+    # sleep targets so every one of those paths becomes a no-op, and tell
+    # logind to ignore idle. This is hardening, not a fix for a specific
+    # trigger — an appliance simply should not be suspendable.
+    systemd.targets.sleep.enable       = false;
+    systemd.targets.suspend.enable     = false;
+    systemd.targets.hibernate.enable   = false;
+    systemd.targets.hybrid-sleep.enable = false;
+    services.logind.settings.Login = {
+      HandlePowerKey  = "ignore";
+      HandleSuspendKey = "ignore";
+      HandleLidSwitch = "ignore";
+      IdleAction      = "ignore";
+    };
+
     # ── Networking ────────────────────────────────────────────────────────────
     # Central default hostname. Install hosts override this: flake.nix's mkHost
     # injects `networking.hostName = lib.mkDefault <folder-name>` for every

--- a/configuration.nix
+++ b/configuration.nix
@@ -105,21 +105,26 @@ in
     # compressed in-RAM swap device instead, sized to half of RAM.
     zramSwap.enable = lib.mkDefault true;
 
-    # ── Never suspend ───────────────────────────────────────────────
+    # ── Never suspend or hibernate ──────────────────────────────────────
     # The box is an always-on appliance (Coder server + k3s) reached over the
-    # LAN and a *.try.coder.app tunnel. A suspend drops the NIC, so the machine
-    # silently falls off the network (no mDNS, no SSH, tunnel dies) until
-    # someone physically wakes it. The shipped image runs a KDE desktop, which
-    # exposes a "Sleep" action, and a stray `systemctl suspend` / Suspend()
-    # D-Bus call would do the same. Mask the suspend target so all of those
-    # paths become a no-op.
+    # LAN and a *.try.coder.app tunnel. Suspending or hibernating drops the
+    # NIC, so the machine silently falls off the network (no mDNS, no SSH,
+    # tunnel dies) until someone physically wakes it. The shipped image runs a
+    # KDE desktop, which exposes Sleep/Hibernate actions, and a stray
+    # `systemctl suspend` / `systemctl hibernate` (or the matching D-Bus call)
+    # would do the same. Mask the suspend, hibernate, and hybrid-sleep targets
+    # so all of those paths become a no-op.
     #
-    # Scope is deliberately narrow: only suspend is blocked. Hibernate/
-    # hybrid-sleep and idle/lid/power-key handling are left at their defaults —
-    # the only thing we care about is the box not suspending itself off the
-    # network.
-    systemd.targets.suspend.enable = false;
-    services.logind.settings.Login.HandleSuspendKey = "ignore";
+    # Scope is deliberately narrow: only the "drop off the network" sleep
+    # states are blocked. Idle/lid/power-key handling is left at NixOS
+    # defaults — the single concern is the box not putting itself to sleep.
+    systemd.targets.suspend.enable      = false;
+    systemd.targets.hibernate.enable    = false;
+    systemd.targets.hybrid-sleep.enable = false;
+    services.logind.settings.Login = {
+      HandleSuspendKey   = "ignore";
+      HandleHibernateKey = "ignore";
+    };
 
     # ── Networking ────────────────────────────────────────────────────────────
     # Central default hostname. Install hosts override this: flake.nix's mkHost


### PR DESCRIPTION
The box is an always-on appliance (Coder server + k3s) reached over the LAN and a `*.try.coder.app` tunnel. A suspend drops the NIC, so the machine silently falls off the network — no mDNS, no SSH, tunnel dead — until someone physically wakes it.

The shipped image runs a KDE desktop (which exposes a **Sleep** action and reacts to the power key), and a stray `systemctl suspend` / `Suspend()` D-Bus call would do the same. This bit me: a box went unreachable, and the journal of the prior boot showed `logind: The system will suspend now!` → `Performing sleep operation 'suspend'` with the NIC dropping its DHCP lease right after — a deliberate `Suspend()` via logind, not an idle timeout (it is a desktop chassis, no lid; logind idle defaults to `ignore`).

## Fix

Mask the sleep targets so every suspend path (desktop Sleep, power key, `systemctl suspend`, `Suspend()` D-Bus) becomes a no-op, and tell logind to ignore the keys/idle:

```nix
systemd.targets.sleep.enable        = false;
systemd.targets.suspend.enable      = false;
systemd.targets.hibernate.enable    = false;
systemd.targets.hybrid-sleep.enable = false;
services.logind.settings.Login = {
  HandlePowerKey   = "ignore";
  HandleSuspendKey = "ignore";
  HandleLidSwitch  = "ignore";
  IdleAction       = "ignore";
};
```

This is hardening, not a fix for one specific trigger — an appliance simply should not be suspendable.

## Validation

- `nixos-rebuild dry-build --flake /etc/nixos-repo` emits `unit-{sleep,suspend,hibernate,hybrid-sleep}.target-disabled` and a rebuilt `etc-systemd-logind.conf`.