### PR TITLE
docs: agent onboarding — HOME agents.md symlink, git safe.directory, rebuild flow

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -64,6 +64,10 @@ sudo git commit -m "feat: describe your change"
 
 Commit regularly. Don't push to remote unless the user explicitly asks.
 
+The `gh` CLI is installed as a helper for working with this repo (opening PRs,
+checking CI, etc.). It is not authenticated out of the box — run `gh auth login`
+once as the login user. Still don't push or open PRs unless explicitly asked.
+
 ## Template Management
 
 Templates live in two places:

--- a/agents.md
+++ b/agents.md
@@ -27,11 +27,16 @@ sudo k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml ...
 
 ```sh
 # Service, package, or config changes — safe, non-destructive:
-sudo nixos-rebuild switch
+cd /etc/nixos-repo && sudo nixos-rebuild switch --flake /etc/nixos-repo
 
 # Desktop stack (KDE, SDDM, Xorg, Wayland) — must reboot:
-sudo nixos-rebuild boot && sudo reboot
+cd /etc/nixos-repo && sudo nixos-rebuild boot --flake /etc/nixos-repo && sudo reboot
 ```
+
+The repo is baked onto the box at **`/etc/nixos-repo`** (the canonical flake;
+`nixosConfigurations.<hostname>`, auto-selected by the running hostname). Edit
+files there, then rebuild. Always pass `--flake /etc/nixos-repo` (or `cd` into
+it and use `--flake .`) — see the `/etc/nixos` pitfall below.
 
 `nixos-rebuild switch` triggers the `coder-template-sync` activation script, which runs `terraform apply` in `coderd/` and pushes any template changes to Coder. The `/etc/coder/session-token` it needs is populated automatically by `coder-init-admin.service` on first boot, so this just works post-install.
 
@@ -160,6 +165,8 @@ sudo k3s kubectl describe pod -n coder-workspaces <pod-name>
 - **Tailscale auth doesn't re-run** — `tailscale-autoauth` has `RemainAfterExit = true`. If you change auth key config, run `sudo systemctl restart tailscale-autoauth`.
 - **Template sync skips**, if `/etc/coder/session-token` is empty, the activation script exits cleanly. The token is auto-populated by `coder-init-admin.service`; if it's missing, check `journalctl -u coder-init-admin`.
 - **`coder` binary path** — the binary is in PATH via NixOS environment; don't hardcode nix store paths in scripts (they change with every package update).
+- **`--flake /etc/nixos` fails** — `/etc/nixos` is a plain dir holding only a `flake.nix` *symlink* into `/etc/nixos-repo`. Nix follows the symlink into the store but can't find the sibling files (configuration.nix, hosts/, nixos/), dying with `path '/nix/store/...-source/etc/nixos-repo/flake.nix' does not exist`. Always rebuild against the real tree: `--flake /etc/nixos-repo` (or `cd /etc/nixos-repo && nixos-rebuild switch --flake .`).
+- **`Git tree '/etc/nixos-repo' is dirty` warning** — harmless. `hosts/<host>/{local.nix,facter.json}` are gitignored and intent-to-added by the installer, so the tree always reads "dirty". After editing them, re-mark intent-to-add so the flake sees them: `sudo git -C /etc/nixos-repo add --intent-to-add -f hosts/<host>/local.nix hosts/<host>/facter.json`.
 - **ScreenConnect blank screen** — if SC shows a black/blank view, SDDM may have fallen back to Wayland. Ensure `services.displayManager.sddm.wayland.enable = false` and `services.displayManager.defaultSession = "plasmax11"` in `configuration.nix`, then `nixos-rebuild boot && reboot`.
 
 ## Wildcard App Access (TODO)

--- a/configuration.nix
+++ b/configuration.nix
@@ -230,7 +230,7 @@ in
     nixpkgs.config.allowUnfree = true;
 
     environment.systemPackages = with pkgs; [
-      git vim curl wget htop jq pciutils usbutils coder terraform vlc
+      git vim curl wget htop jq pciutils usbutils coder terraform gh vlc
     ];
 
     nix.settings.experimental-features = [ "nix-command" "flakes" ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -297,7 +297,23 @@ in
       "d /etc/coder 0750 root coder -"
       "f /etc/coder/session-token 0600 coder coder -"
       "z /etc/coder/session-token 0600 coder coder -"
-    ];
+    ]
+    # Surface the agent/dev guide in each normal user's home so an agent that
+    # lands in $HOME (or a human on first login) finds it immediately. The repo
+    # itself lives at /etc/nixos-repo; agents.md documents the rebuild workflow.
+    # `L+` recreates the symlink on every boot so it tracks the canonical file.
+    ++ (lib.mapAttrsToList
+         (_: u: "L+ ${u.home}/agents.md - - - - /etc/nixos-repo/agents.md")
+         (lib.filterAttrs (_: u: u.isNormalUser && u.home != null) config.users.users));
+
+    # Whitelist the root-owned baked repo so interactive `git`/`nix` as the
+    # login user (or via sudo) don't trip git's dubious-ownership guard with
+    # "repository path '/etc/nixos-repo' is not owned by current user". The
+    # box's own services already pass `-c safe.directory=...` inline; this is
+    # purely for humans/agents running git by hand. Harmless on appliance ISOs
+    # where /etc/nixos-repo is a read-only store path (not a git repo).
+    programs.git.enable = true;
+    programs.git.config.safe.directory = [ "/etc/nixos-repo" ];
 
     # ── Coder server ──────────────────────────────────────────────────────────
     # Base env vars live here. Secrets (admin creds, OAuth, etc.) are merged in


### PR DESCRIPTION
Make the box easier for agents (and humans) to work on after an `install.sh` install.

## What & why

- **`programs.git` safe.directory** whitelists the root-owned `/etc/nixos-repo` so interactive `git`/`nix` as the login user (or via `sudo`) no longer trip git's dubious-ownership guard (`repository path ... is not owned by current user`). The box's own services already pass `-c safe.directory=...` inline; this only covers ad-hoc use. Harmless on appliance ISOs where the repo is a read-only Nix store path (not a git repo).
- **`~/agents.md` symlink** via a tmpfiles `L+` rule into every normal-user home, so an agent landing in `$HOME` finds the guide immediately. The motd only shows on interactive login — not over `ssh host 'cmd'`, which is how an automation agent connects — so a file on disk is the reliable discovery path.
- **`agents.md`**: document rebuilding via `--flake /etc/nixos-repo`, the `/etc/nixos` symlink-dir trap (`--flake /etc/nixos` fails because that dir holds only a `flake.nix` symlink, so Nix can't find the sibling files), and the harmless `Git tree dirty` warning + the intent-to-add re-add command.

## Validation

- `nixos-rebuild dry-build --flake /etc/nixos-repo` — evaluates clean; `~/agents.md` symlink created on switch and resolves.