### PR TITLE
feat: hide the AI Tasks UI

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -327,6 +327,9 @@ in
         DOCKER_HOST                    = "unix:///run/user/${toString coderUid}/podman/podman.sock";
         # Enable all experiments: Coder AI agents, MCP, etc.
         CODER_EXPERIMENTS              = "*";
+        # Hide the AI Tasks UI from the dashboard. Experiments above enable the
+        # underlying features (agents, MCP); this just keeps the Tasks tab off.
+        CODER_HIDE_AI_TASKS            = "true";
       };
 
       serviceConfig = {


### PR DESCRIPTION
Set `CODER_HIDE_AI_TASKS=true` on `coder.service`.

The box runs with `CODER_EXPERIMENTS="*"`, which surfaces the **AI Tasks** tab in the dashboard. This flag (`--hide-ai-tasks` / `CODER_HIDE_AI_TASKS`) hides the Tasks UI while leaving the underlying experiments (agents, MCP, etc.) enabled — so workspace AI features keep working, the Tasks tab just isnt shown.

## Validation

- `nixos-rebuild dry-build --flake /etc/nixos-repo` — evaluates clean.