### PR TITLE
feat: migrate from ext4 to ZFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ default `networking.hostName = "coder-box"` (set in `configuration.nix`).
 
 Two community tools do the heavy lifting:
 
-- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time and writes a unique ZFS `networking.hostId` per host. ZFS gives cheap snapshots (auto-snapshot of the root dataset, so a bad rebuild rolls back in seconds), zstd compression, and checksum/scrub integrity.
+- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time; the ZFS `networking.hostId` is derived in Nix from the hostname (sha256 substring), so each host gets a distinct id automatically. ZFS gives cheap snapshots (auto-snapshot of the root dataset, so a bad rebuild rolls back in seconds), zstd compression, and checksum/scrub integrity.
 - [`nixos-facter`](https://github.com/nix-community/nixos-facter) writes a JSON hardware report (`facter.json`) that replaces `hardware-configuration.nix` on new hosts. The `nixos-facter-modules` module reads it to set kernel modules, microcode, GPU drivers, and so on.
 
 ## Installing on a new machine

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ default `networking.hostName = "coder-box"` (set in `configuration.nix`).
 
 Two community tools do the heavy lifting:
 
-- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time; the ZFS `networking.hostId` is derived in Nix from the hostname (sha256 substring), so each host gets a distinct id automatically. ZFS gives cheap snapshots (auto-snapshot of the root dataset, so a bad rebuild rolls back in seconds), zstd compression, and checksum/scrub integrity.
+- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time; the ZFS `networking.hostId` is derived in Nix from the hostname (sha256 substring), so each host gets a distinct id automatically. ZFS gives cheap on-demand snapshots (take one before a risky rebuild and roll back in seconds), zstd compression, and checksum/scrub integrity.
 - [`nixos-facter`](https://github.com/nix-community/nixos-facter) writes a JSON hardware report (`facter.json`) that replaces `hardware-configuration.nix` on new hosts. The `nixos-facter-modules` module reads it to set kernel modules, microcode, GPU drivers, and so on.
 
 ## Installing on a new machine

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ local.nix.example          # template copied to hosts/<host>/local.nix by instal
 .gitignore                 # ignores hosts/*/local.nix
 install.sh                 # one-shot installer: disko + nixos-install + bake /etc/nixos-repo
 nixos/
-  disko-standard.nix       # shared disko config: 1 GB EFI + 16 GB swap + ext4 root on a single disk
+  disko-standard.nix       # shared disko config: 1 GB EFI + ZFS root pool on a single disk
   tailscale.nix            # Tailscale module (auth key, no --ssh flag)
   k3s-sysbox.nix           # k3s + sysbox-runc runtime class
   k3s-podman.nix           # k3s + rootless Podman socket
@@ -88,7 +88,7 @@ default `networking.hostName = "coder-box"` (set in `configuration.nix`).
 
 Two community tools do the heavy lifting:
 
-- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / 16 GB swap / ext4 root). `install.sh` picks the device at install time.
+- [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time and writes a unique ZFS `networking.hostId` per host. ZFS gives cheap snapshots (auto-snapshot of the root dataset, so a bad rebuild rolls back in seconds), zstd compression, and checksum/scrub integrity.
 - [`nixos-facter`](https://github.com/nix-community/nixos-facter) writes a JSON hardware report (`facter.json`) that replaces `hardware-configuration.nix` on new hosts. The `nixos-facter-modules` module reads it to set kernel modules, microcode, GPU drivers, and so on.
 
 ## Installing on a new machine
@@ -196,7 +196,7 @@ sudo dd if=out/appliance-iso/iso/coder-box-appliance-*.iso of=/dev/sdX bs=4M sta
 
 Built with [disko](https://github.com/nix-community/disko)'s image builder, so
 it carries the real on-disk GPT layout from `nixos/disko-standard.nix` (1 GB
-ESP + ext4 root) and **state survives reboots**, exactly like a machine you ran
+ESP + ZFS root pool) and **state survives reboots**, exactly like a machine you ran
 `install.sh` on. `hosts/_appliance-disk/default.nix` imports
 `disko-standard.nix` + `box-turnkey.nix`.
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -100,6 +100,39 @@ in
     boot.loader.systemd-boot.enable = lib.mkDefault true;
     boot.loader.efi.canTouchEfiVariables = lib.mkDefault true;
 
+    # ── Filesystem: ZFS root ───────────────────────────────────────────────────
+    # The standard single-disk layout (nixos/disko-standard.nix) puts root on a
+    # ZFS pool ("rpool"). The kernel needs the ZFS module available at boot to
+    # import it; declare it here so every host that follows the standard layout
+    # (and the prebuilt appliance images) boots. Hosts that predate disko and
+    # still mount an ext4 root (e.g. coder-thinkcentre) are unaffected — ZFS
+    # support being present costs nothing if no ZFS pool exists.
+    boot.supportedFilesystems = [ "zfs" ];
+
+    # ZFS refuses to import a pool unless networking.hostId is set (it stamps
+    # the pool so it can't be imported on two machines at once). This shared
+    # mkDefault lets the prebuilt appliance images build and boot; install.sh
+    # writes a freshly generated, unique hostId into hosts/<host>/default.nix so
+    # every installed box differs. Override per-host if you ever clone an image.
+    networking.hostId = lib.mkDefault "c0de0b09";
+
+    # Keep the pool healthy and SSDs happy: periodic scrub (verifies every
+    # block against its checksum and self-heals where possible) and weekly TRIM.
+    services.zfs.autoScrub.enable = lib.mkDefault true;
+    services.zfs.trim.enable      = lib.mkDefault true;
+
+    # Automatic snapshots of datasets tagged com.sun:auto-snapshot = "true"
+    # (the root dataset in disko-standard.nix). This is the whole point of the
+    # ZFS move: a bad nixos-rebuild or experiment can be rolled back in seconds.
+    services.zfs.autoSnapshot = {
+      enable     = lib.mkDefault true;
+      frequent   = lib.mkDefault 4;   # 15-min snapshots, keep 4
+      hourly     = lib.mkDefault 24;
+      daily      = lib.mkDefault 7;
+      weekly     = lib.mkDefault 4;
+      monthly    = lib.mkDefault 3;
+    };
+
     # ── Swap ──────────────────────────────────────────────────────────────────
     # No on-disk swap partition (see nixos/disko-standard.nix). Use a
     # compressed in-RAM swap device instead, sized to half of RAM.

--- a/configuration.nix
+++ b/configuration.nix
@@ -110,11 +110,14 @@ in
     boot.supportedFilesystems = [ "zfs" ];
 
     # ZFS refuses to import a pool unless networking.hostId is set (it stamps
-    # the pool so it can't be imported on two machines at once). This shared
-    # mkDefault lets the prebuilt appliance images build and boot; install.sh
-    # writes a freshly generated, unique hostId into hosts/<host>/default.nix so
-    # every installed box differs. Override per-host if you ever clone an image.
-    networking.hostId = lib.mkDefault "c0de0b09";
+    # the pool so it can't be imported on two machines at once). Derive it in
+    # Nix from the hostname: the first 8 hex digits of its sha256. Deterministic
+    # per host, and since every install host gets a unique networking.hostName
+    # (flake.nix injects the folder name) each box ends up with a distinct id —
+    # no shell-side generation needed. mkDefault so a host can still override.
+    networking.hostId =
+      lib.mkDefault (builtins.substring 0 8
+        (builtins.hashString "sha256" config.networking.hostName));
 
     # Keep the pool healthy and SSDs happy: periodic scrub (verifies every
     # block against its checksum and self-heals where possible) and weekly TRIM.

--- a/configuration.nix
+++ b/configuration.nix
@@ -124,18 +124,6 @@ in
     services.zfs.autoScrub.enable = lib.mkDefault true;
     services.zfs.trim.enable      = lib.mkDefault true;
 
-    # Automatic snapshots of datasets tagged com.sun:auto-snapshot = "true"
-    # (the root dataset in disko-standard.nix). This is the whole point of the
-    # ZFS move: a bad nixos-rebuild or experiment can be rolled back in seconds.
-    services.zfs.autoSnapshot = {
-      enable     = lib.mkDefault true;
-      frequent   = lib.mkDefault 4;   # 15-min snapshots, keep 4
-      hourly     = lib.mkDefault 24;
-      daily      = lib.mkDefault 7;
-      weekly     = lib.mkDefault 4;
-      monthly    = lib.mkDefault 3;
-    };
-
     # ── Swap ──────────────────────────────────────────────────────────────────
     # No on-disk swap partition (see nixos/disko-standard.nix). Use a
     # compressed in-RAM swap device instead, sized to half of RAM.

--- a/hosts/_appliance-disk/default.nix
+++ b/hosts/_appliance-disk/default.nix
@@ -4,7 +4,7 @@
 # auto-discovery), so this host is exposed as `nixosConfigurations._appliance-disk`.
 # Unlike the appliance ISO (hosts/_appliance_iso), this builds a *persistent* disk
 # image (qcow2 or raw) using disko's image builder: it carries the real on-disk
-# GPT layout (1 GB ESP + ext4 root from nixos/disko-standard.nix) and state
+# GPT layout (1 GB ESP + ZFS root pool from nixos/disko-standard.nix) and state
 # survives reboots, exactly like a machine you ran install.sh on.
 #
 # Build (the format is chosen at build time, see Makefile / README):
@@ -26,7 +26,7 @@
 
 {
   imports = [
-    ../../nixos/disko-standard.nix       # 1 GB ESP + ext4 root single-disk layout
+    ../../nixos/disko-standard.nix       # 1 GB ESP + ZFS root pool single-disk layout
     ../../nixos/_images/box-turnkey.nix  # shared turn-key config (login + Coder bootstrap)
   ] ++ lib.optional (builtins.pathExists ./local.nix) ./local.nix;
 

--- a/install.sh
+++ b/install.sh
@@ -342,6 +342,10 @@ mkdir -p "$HOST_DIR"
 # default.nix: disko-standard layout, target disk override, conditional
 # local.nix, facter when present.
 if [[ ! -f "$HOST_DIR/default.nix" ]]; then
+  # ZFS stamps the pool with networking.hostId so it can't be imported on two
+  # machines at once. Generate a unique 8-hex-digit hostId per install so every
+  # box differs (configuration.nix only sets a shared mkDefault for the images).
+  HOSTID=$(head -c4 /dev/urandom | od -A none -t x1 | tr -d ' \n')
   cat > "$HOST_DIR/default.nix" <<NIX
 # Hardware: ${HARDWARE_DESC_ARG}.
 #
@@ -356,6 +360,9 @@ if [[ ! -f "$HOST_DIR/default.nix" ]]; then
 
   # Target disk for disko-standard.
   disko.devices.disk.main.device = lib.mkForce "${DISK_ARG}";
+
+  # Unique ZFS hostId for this machine (required by the ZFS root pool).
+  networking.hostId = "${HOSTID}";
 
   # facter.json overrides hardware-detection bits of hardware-configuration.nix.
   hardware.facter.reportPath =

--- a/install.sh
+++ b/install.sh
@@ -342,11 +342,6 @@ mkdir -p "$HOST_DIR"
 # default.nix: disko-standard layout, target disk override, conditional
 # local.nix, facter when present.
 if [[ ! -f "$HOST_DIR/default.nix" ]]; then
-  # ZFS stamps the pool with networking.hostId so it can't be imported on two
-  # machines at once. Derive a stable 8-hex-digit hostId from the sha256 of the
-  # hostname so every box differs (configuration.nix only sets a shared
-  # mkDefault for the images); deterministic, so re-running keeps the same id.
-  HOSTID=$(printf '%s' "$HOSTNAME_ARG" | sha256sum | cut -c1-8)
   cat > "$HOST_DIR/default.nix" <<NIX
 # Hardware: ${HARDWARE_DESC_ARG}.
 #
@@ -361,9 +356,6 @@ if [[ ! -f "$HOST_DIR/default.nix" ]]; then
 
   # Target disk for disko-standard.
   disko.devices.disk.main.device = lib.mkForce "${DISK_ARG}";
-
-  # Unique ZFS hostId for this machine (required by the ZFS root pool).
-  networking.hostId = "${HOSTID}";
 
   # facter.json overrides hardware-detection bits of hardware-configuration.nix.
   hardware.facter.reportPath =

--- a/install.sh
+++ b/install.sh
@@ -343,9 +343,10 @@ mkdir -p "$HOST_DIR"
 # local.nix, facter when present.
 if [[ ! -f "$HOST_DIR/default.nix" ]]; then
   # ZFS stamps the pool with networking.hostId so it can't be imported on two
-  # machines at once. Generate a unique 8-hex-digit hostId per install so every
-  # box differs (configuration.nix only sets a shared mkDefault for the images).
-  HOSTID=$(head -c4 /dev/urandom | od -A none -t x1 | tr -d ' \n')
+  # machines at once. Derive a stable 8-hex-digit hostId from the sha256 of the
+  # hostname so every box differs (configuration.nix only sets a shared
+  # mkDefault for the images); deterministic, so re-running keeps the same id.
+  HOSTID=$(printf '%s' "$HOSTNAME_ARG" | sha256sum | cut -c1-8)
   cat > "$HOST_DIR/default.nix" <<NIX
 # Hardware: ${HARDWARE_DESC_ARG}.
 #

--- a/nixos/disko-standard.nix
+++ b/nixos/disko-standard.nix
@@ -71,9 +71,7 @@
     # so there is no separate import/mount unit ordering to worry about.
     zpool.rpool = {
       type = "zpool";
-      mode = "";
-      # ashift=12 → 4 KiB sectors, correct for every modern SSD/NVMe/HDD.
-      options.ashift = "12";
+
       rootFsOptions = {
         # zstd: good ratio, negligible CPU cost; helps the Nix store especially.
         compression = "zstd";
@@ -84,12 +82,14 @@
         # The pool itself isn't a mountpoint; datasets carry the mounts.
         mountpoint = "none";
       };
+
       datasets = {
         # Root filesystem.
         root = {
           type = "zfs_fs";
           mountpoint = "/";
         };
+
         # The Nix store is fully reproducible from the flake and churns
         # constantly; atime off avoids needless write amplification.
         nix = {

--- a/nixos/disko-standard.nix
+++ b/nixos/disko-standard.nix
@@ -5,9 +5,9 @@
 # configuration.nix: zramSwap.enable). Works on any single block device
 # (NVMe, SATA SSD/HDD, USB, virtio).
 #
-# Why ZFS instead of ext4: cheap, instant snapshots (roll back a bad
-# nixos-rebuild or an experiment in seconds), transparent zstd compression,
-# and on-disk checksums/scrubbing. The pool is imported by name ("rpool"),
+# Why ZFS instead of ext4: cheap, instant on-demand snapshots (take one before
+# a risky nixos-rebuild and roll back in seconds), transparent zstd
+# compression, and on-disk checksums/scrubbing. The pool is imported by name ("rpool"),
 # not by device node, so the layout stays portable across machines that
 # follow it (NVMe/SATA/USB/virtio) — the same property the old ext4 layout
 # got from filesystem labels.
@@ -81,30 +81,21 @@
         # avoids the slow on-disk xattr dir layout.
         acltype = "posixacl";
         xattr = "sa";
-        # Off by default at the pool root; flipped on per-dataset below so
-        # automatic snapshots only cover the data we care to roll back.
-        "com.sun:auto-snapshot" = "false";
         # The pool itself isn't a mountpoint; datasets carry the mounts.
         mountpoint = "none";
       };
       datasets = {
-        # Root filesystem — snapshot this so a bad rebuild/experiment can be
-        # rolled back. services.zfs.autoSnapshot (configuration.nix) takes
-        # periodic snapshots of every dataset with auto-snapshot = "true".
+        # Root filesystem.
         root = {
           type = "zfs_fs";
           mountpoint = "/";
-          options."com.sun:auto-snapshot" = "true";
         };
-        # The Nix store is fully reproducible from the flake, large, and churns
-        # constantly — snapshotting it just wastes space, so leave it off.
+        # The Nix store is fully reproducible from the flake and churns
+        # constantly; atime off avoids needless write amplification.
         nix = {
           type = "zfs_fs";
           mountpoint = "/nix";
-          options = {
-            "com.sun:auto-snapshot" = "false";
-            atime = "off";
-          };
+          options.atime = "off";
         };
       };
     };

--- a/nixos/disko-standard.nix
+++ b/nixos/disko-standard.nix
@@ -12,10 +12,9 @@
 # follow it (NVMe/SATA/USB/virtio) — the same property the old ext4 layout
 # got from filesystem labels.
 #
-# ZFS requires a unique networking.hostId per machine. A shared mkDefault
-# lives in configuration.nix so the prebuilt appliance images build; install.sh
-# writes a freshly generated, per-host hostId into hosts/<host>/default.nix so
-# every installed box is unique.
+# ZFS requires a unique networking.hostId per machine. configuration.nix
+# derives it in Nix from the hostname (first 8 hex digits of its sha256), so
+# every host with a distinct hostName gets a distinct id automatically.
 #
 # Hosts that follow this layout import the module and override the disk
 # device path if needed (the default is /dev/nvme0n1, the current demo box

--- a/nixos/disko-standard.nix
+++ b/nixos/disko-standard.nix
@@ -1,11 +1,21 @@
 # Standard UEFI + GPT single-disk layout for the Coder demo boxes.
 #
-# 1 GB EFI System Partition and an ext4 root taking the rest of the disk.
-# No on-disk swap partition; swap is provided at runtime via zram (see
+# 1 GB EFI System Partition and a ZFS pool ("rpool") taking the rest of the
+# disk. No on-disk swap partition; swap is provided at runtime via zram (see
 # configuration.nix: zramSwap.enable). Works on any single block device
 # (NVMe, SATA SSD/HDD, USB, virtio).
-# Partitions are labelled so the running NixOS mounts by label, not UUID,
-# which makes the layout portable across machines that follow it.
+#
+# Why ZFS instead of ext4: cheap, instant snapshots (roll back a bad
+# nixos-rebuild or an experiment in seconds), transparent zstd compression,
+# and on-disk checksums/scrubbing. The pool is imported by name ("rpool"),
+# not by device node, so the layout stays portable across machines that
+# follow it (NVMe/SATA/USB/virtio) — the same property the old ext4 layout
+# got from filesystem labels.
+#
+# ZFS requires a unique networking.hostId per machine. A shared mkDefault
+# lives in configuration.nix so the prebuilt appliance images build; install.sh
+# writes a freshly generated, per-host hostId into hosts/<host>/default.nix so
+# every installed box is unique.
 #
 # Hosts that follow this layout import the module and override the disk
 # device path if needed (the default is /dev/nvme0n1, the current demo box
@@ -21,36 +31,80 @@
 { lib, ... }:
 
 {
-  disko.devices.disk.main = {
-    type = "disk";
-    # Override per-host. /dev/nvme0n1 is the default since the current
-    # demo box is NVMe; SATA hosts override to /dev/sda etc. install.sh
-    # writes the override into hosts/<host>/default.nix based on the disk
-    # picked at install time.
-    device = lib.mkDefault "/dev/nvme0n1";
-    content = {
-      type = "gpt";
-      partitions = {
-        ESP = {
-          priority = 1;
-          name = "ESP";
-          size = "1G";
-          type = "EF00";
-          content = {
-            type = "filesystem";
-            format = "vfat";
-            mountpoint = "/boot";
-            mountOptions = [ "fmask=0077" "dmask=0077" ];
+  disko.devices = {
+    disk.main = {
+      type = "disk";
+      # Override per-host. /dev/nvme0n1 is the default since the current
+      # demo box is NVMe; SATA hosts override to /dev/sda etc. install.sh
+      # writes the override into hosts/<host>/default.nix based on the disk
+      # picked at install time.
+      device = lib.mkDefault "/dev/nvme0n1";
+      content = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            priority = 1;
+            name = "ESP";
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "fmask=0077" "dmask=0077" ];
+            };
+          };
+          zfs = {
+            priority = 2;
+            name = "zfs";
+            size = "100%";
+            content = {
+              type = "zfs";
+              pool = "rpool";
+            };
           };
         };
+      };
+    };
+
+    # Single-disk pool ("rpool", mode = "" → no redundancy). Datasets are
+    # mounted by the disko-generated fileSystems entries (legacy mountpoints),
+    # so there is no separate import/mount unit ordering to worry about.
+    zpool.rpool = {
+      type = "zpool";
+      mode = "";
+      # ashift=12 → 4 KiB sectors, correct for every modern SSD/NVMe/HDD.
+      options.ashift = "12";
+      rootFsOptions = {
+        # zstd: good ratio, negligible CPU cost; helps the Nix store especially.
+        compression = "zstd";
+        # POSIX ACLs + xattrs stored in the inode (sa) — needed by systemd and
+        # avoids the slow on-disk xattr dir layout.
+        acltype = "posixacl";
+        xattr = "sa";
+        # Off by default at the pool root; flipped on per-dataset below so
+        # automatic snapshots only cover the data we care to roll back.
+        "com.sun:auto-snapshot" = "false";
+        # The pool itself isn't a mountpoint; datasets carry the mounts.
+        mountpoint = "none";
+      };
+      datasets = {
+        # Root filesystem — snapshot this so a bad rebuild/experiment can be
+        # rolled back. services.zfs.autoSnapshot (configuration.nix) takes
+        # periodic snapshots of every dataset with auto-snapshot = "true".
         root = {
-          priority = 2;
-          name = "root";
-          size = "100%";
-          content = {
-            type = "filesystem";
-            format = "ext4";
-            mountpoint = "/";
+          type = "zfs_fs";
+          mountpoint = "/";
+          options."com.sun:auto-snapshot" = "true";
+        };
+        # The Nix store is fully reproducible from the flake, large, and churns
+        # constantly — snapshotting it just wastes space, so leave it off.
+        nix = {
+          type = "zfs_fs";
+          mountpoint = "/nix";
+          options = {
+            "com.sun:auto-snapshot" = "false";
+            atime = "off";
           };
         };
       };


### PR DESCRIPTION
Closes #19.

Migrates the standard single-disk layout from an ext4 root to a ZFS root pool, mainly for cheap on-demand snapshots (take one before a risky `nixos-rebuild` and roll back in seconds), plus zstd compression and checksum/scrub integrity.

## Changes

- **`nixos/disko-standard.nix`** — ESP unchanged; the rest of the disk is now a single-disk zpool (`rpool`) with `root` (`/`) and `nix` (`/nix`, `atime=off`) datasets. Pool-wide `zstd` compression, `acltype=posixacl`, `xattr=sa`, `ashift=12`. Imported by name, keeping the layout portable across NVMe/SATA/USB/virtio (the role labels used to fill for the ext4 layout).
- **`configuration.nix`** — `boot.supportedFilesystems = [ "zfs" ]`, ZFS housekeeping (`autoScrub`, `trim`), and a `networking.hostId` derived in Nix from the hostname: `substring 0 8 (hashString "sha256" networking.hostName)`. Deterministic per host, and since each install host gets a unique hostName, each box gets a distinct id automatically. Harmless for the legacy ext4 host (`coder-thinkcentre`).
- **`README.md` / host comments** — describe the ZFS layout instead of ext4.

## Validation

- `nix eval` of every host (`_appliance-disk`, `_appliance_iso`, `_installer-iso`, `coder-thinkcentre`) — all `toplevel.drvPath` evaluate, plus `diskoImages.drvPath`.
- Generated `fileSystems`: `{"/":"rpool/root" (zfs), "/nix":"rpool/nix" (zfs), "/boot": vfat ESP}`.
- hostId resolves to the expected sha256 substring (`coder-box` → `c39cab9c`).

## Note

Periodic automatic snapshots are **not** configured (ZFS still supports on-demand snapshots). The legacy `coder-thinkcentre` host keeps its ext4 root (predates disko); this applies to fresh installs and the appliance images — an in-place ext4→ZFS conversion would require a reinstall/restore.
