### PR TITLE
fix(k3s): coder.service won't auto-start on install (hard dep on flaky namespace oneshot)

### DIFF
--- a/nixos/k3s-podman.nix
+++ b/nixos/k3s-podman.nix
@@ -191,9 +191,17 @@ in
     # Inject KUBECONFIG for Terraform's kubernetes provider, and order after
     # coder-k3s-namespace so the coder-workspaces namespace exists before
     # Coder's first workspace build (else it fails: namespace not found).
+    #
+    # NOTE: use `wants` (soft), NOT `requires` (hard), for the namespace dep.
+    # With `after` + `requires`, a failed coder-k3s-namespace.service (which
+    # runs `set -euo pipefail` and can flake on a cold first boot if the k3s
+    # API isn't accepting requests yet) would prevent coder.service from
+    # starting at all. We only want ordering here; the namespace service is
+    # already `wantedBy = multi-user.target`, so `wants` keeps it pulled in and
+    # ordered before coder without letting a transient flake block the server.
     systemd.services.coder = {
-      after    = [ "coder-k3s-namespace.service" ];
-      requires = [ "coder-k3s-namespace.service" ];
+      after = [ "coder-k3s-namespace.service" ];
+      wants = [ "coder-k3s-namespace.service" ];
       environment = {
         KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
       };

--- a/nixos/k3s-sysbox.nix
+++ b/nixos/k3s-sysbox.nix
@@ -351,9 +351,17 @@ in
     # Inject KUBECONFIG for Terraform's kubernetes provider, and order after
     # coder-k3s-namespace so the coder-workspaces namespace exists before
     # Coder's first workspace build (else it fails: namespace not found).
+    #
+    # NOTE: use `wants` (soft), NOT `requires` (hard), for the namespace dep.
+    # With `after` + `requires`, a failed coder-k3s-namespace.service (which
+    # runs `set -euo pipefail` and can flake on a cold first boot if the k3s
+    # API isn't accepting requests yet) would prevent coder.service from
+    # starting at all. We only want ordering here; the namespace service is
+    # already `wantedBy = multi-user.target`, so `wants` keeps it pulled in and
+    # ordered before coder without letting a transient flake block the server.
     systemd.services.coder = {
-      after    = [ "coder-k3s-namespace.service" ];
-      requires = [ "coder-k3s-namespace.service" ];
+      after = [ "coder-k3s-namespace.service" ];
+      wants = [ "coder-k3s-namespace.service" ];
       environment = {
         KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
       };


### PR DESCRIPTION
## Problem

`coder.service` does not start automatically on a fresh install / first boot.

## Root cause

the k3s ordering fix (`69b1d48`, *"fix(k3s): order coder.service after coder-k3s-namespace"*) gave `coder.service` **both** `after` and `requires` on `coder-k3s-namespace.service` in `nixos/k3s-sysbox.nix` and `nixos/k3s-podman.nix`:

```nix
systemd.services.coder = {
  after    = [ "coder-k3s-namespace.service" ];
  requires = [ "coder-k3s-namespace.service" ];   # ← hard dep
};
```

The intent was just **ordering**. But `requires` is a **hard dependency**: if the namespace oneshot fails, systemd refuses to start `coder.service` at all.

That oneshot can fail on a cold first boot. Its script runs under `set -euo pipefail` and only waits for the kubeconfig **file** to exist — not for the k3s API to accept requests. On a fresh boot the API server is frequently not ready when the file appears, so `kubectl apply` errors, the oneshot fails, and `requires=` propagates that failure → **coder.service never starts automatically** (it only comes up after a later manual restart once k3s is ready). That matches the reported "doesn't start on install" symptom.

This is the same cold-boot race the surrounding code already fights (e.g. the `k3s-wait-api-ready` ExecStartPost).

## Fix

Switch the namespace dependency from `requires` (hard) to `wants` (soft) in both modules, keeping the `after` ordering:

```nix
systemd.services.coder = {
  after = [ "coder-k3s-namespace.service" ];
  wants = [ "coder-k3s-namespace.service" ];
};
```

`coder-k3s-namespace.service` is still `wantedBy = multi-user.target`, so it's pulled in and ordered before Coder on every boot — a transient flake just no longer blocks the server. PostgreSQL stays a hard `requires` (Coder genuinely can't run without its DB).

## Validation

`nix eval` of the `coder-thinkcentre` host config:
- `coder.after` → includes `coder-k3s-namespace.service` (ordering preserved)
- `coder.wants` → now includes `coder-k3s-namespace.service` (soft dep)
- `coder.requires` → `["postgresql.service"]` (namespace no longer hard-required)

Flake still evaluates cleanly.

## Note

This fixes the dependency strength only. The namespace oneshot's own cold-boot fragility (waiting on the kubeconfig file rather than API `/readyz`) still exists but is now non-fatal to Coder. Happy to harden that script to poll the API like `k3s-wait-api-ready` in a follow-up if desired.