### PR TITLE
feat: interactive installer.sh (gum) + getopt flag parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ From a NixOS live USB on the target box, with network access (any reasonably rec
 ```sh
 nix-shell -p git --run "git clone https://github.com/coder/box /tmp/box"
 cd /tmp/box
-sudo ./install.sh
+sudo ./install.sh --interactive
 ```
 
-The installer prompts for a target disk. Anything else not passed as a flag falls back to a default: hostname `coder-nixos`, Coder admin `admin@coder.com` / `PleaseChangeMe1234`, OS login `coderbox` / `PleaseChangeMe1234`. Passwords in the summary are obfuscated, unless they are left as defaults.
+With `--interactive` (`-i`) the installer prompts for any value not already passed as a flag, including a target disk picker. Each prompt offers a default; press Enter to accept it. Without `--interactive`, a target disk must be given via `--disk` (there is no safe default). Other values not passed as a flag fall back to a default: hostname `coder-box-<random>` (e.g. `coder-box-deadbeef`), Coder admin `admin@coder.com` / `PleaseChangeMe1234`, OS login `coderbox` / `PleaseChangeMe1234`. Passwords in the summary are obfuscated, unless they are left as defaults.
 
 For a fully unattended install, pass every value as a flag:
 

--- a/install.sh
+++ b/install.sh
@@ -8,14 +8,15 @@
 #
 #   nix-shell -p git --run "git clone https://github.com/coder/box /tmp/box"
 #   cd /tmp/box
-#   sudo ./install.sh                  # interactive disk picker, defaults for the rest
+#   sudo ./install.sh --interactive   # prompt for everything not passed as a flag
+#   sudo ./install.sh --disk /dev/sda --interactive
 #   sudo ./install.sh --disk /dev/sda --yes
 #
 # Flags (anything you don't pass uses the default shown):
 #
-#   --hostname NAME                  coder-nixos
+#   --hostname NAME                  coder-box-<random> (e.g. coder-box-deadbeef)
 #   --hardware-desc TEXT             auto (dmidecode)
-#   --disk PATH                      interactive picker
+#   --disk PATH                      required (or pick interactively with --interactive)
 #   --coder-admin-email EMAIL        admin@coder.com
 #   --coder-admin-password PW        PleaseChangeMe1234
 #   --coder-admin-password-file P    read first line as password
@@ -24,8 +25,10 @@
 #   --nixos-password-file PATH       read first line as password
 #   --lan-ip IP                      auto-detected
 #   --no-reboot                      skip the final reboot
-#   --yes                            skip the destructive-wipe confirmation
-#   --help                           show this help
+#   --interactive, -i                prompt for any value not passed as a flag
+#                                    (ignored when --yes is given)
+#   --yes, -y                        skip the destructive-wipe confirmation
+#   --help, -h                       show this help
 
 set -euo pipefail
 
@@ -66,15 +69,42 @@ NIXOS_PASSWORD_FILE_ARG=""
 LAN_IP_ARG=""
 NO_REBOOT=0
 ASSUME_YES=0
+INTERACTIVE=0
 
 usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \?//; s/^set -euo.*//' | sed '/^$/N;/^\n$/D'; }
 
 # Require a value for a value-taking flag. Without this, a flag passed as the
 # last token with no argument (e.g. `--coder-admin-password`) expands `$2` under
 # `set -u` and crashes with "$2: unbound variable" instead of a clear message.
+# (GNU getopt already guarantees a value token, but this guard is cheap.)
 need_value() {
   [[ $# -ge 2 ]] || { echo "flag $1 requires a value" >&2; usage >&2; exit 2; }
 }
+
+# Option spec for getopt.
+SHORT_OPTS="iyh"
+LONG_OPTS="hostname:,hardware-desc:,disk:,coder-admin-email:,coder-admin-password:"
+LONG_OPTS+=",coder-admin-password-file:,nixos-username:,nixos-password:,nixos-password-file:"
+LONG_OPTS+=",lan-ip:,no-reboot,interactive,yes,help"
+
+# We rely on GNU getopt to normalise `--flag=value`, bundled short flags, and
+# option order into a canonical token stream terminated by `--`. BSD/macOS
+# getopt has no long-option support, so its output can't be trusted; detect it
+# via its `--version` output (BSD getopt can't parse `--version`, so it echoes
+# the leftover `--`) and bail out with a clear error rather than mis-parsing.
+if [[ "$(getopt --version 2>/dev/null)" == *--* ]]; then
+  echo "error: GNU getopt is required, but BSD getopt was detected." >&2
+  echo "  This installer only runs on a NixOS live USB, which ships GNU getopt." >&2
+  echo "  ...are you even running this on NixOS? ;)" >&2
+  exit 1
+fi
+if ! PARSED="$(getopt --options "$SHORT_OPTS" --longoptions "$LONG_OPTS" \
+                      --name install.sh -- "$@")"; then
+  usage >&2
+  exit 2
+fi
+eval set -- "$PARSED"
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --hostname)              need_value "$@"; HOSTNAME_ARG="$2";              shift 2 ;;
@@ -88,11 +118,24 @@ while [[ $# -gt 0 ]]; do
     --nixos-password-file)   need_value "$@"; NIXOS_PASSWORD_FILE_ARG="$2";   shift 2 ;;
     --lan-ip)                need_value "$@"; LAN_IP_ARG="$2";                shift 2 ;;
     --no-reboot)             NO_REBOOT=1;                    shift ;;
+    --interactive|-i)        INTERACTIVE=1;                  shift ;;
     --yes|-y)                ASSUME_YES=1;                   shift ;;
     --help|-h)               usage; exit 0 ;;
+    --) shift; break ;;
     *) echo "unknown flag: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
+
+# Reject stray positionals (e.g. tokens after `--`); this installer takes none.
+if [[ $# -gt 0 ]]; then
+  echo "unexpected argument: $1" >&2; usage >&2; exit 2
+fi
+
+# --interactive is meaningless in unattended mode: --yes assumes defaults and
+# skips confirmation, so silently ignore an accompanying --interactive.
+if [[ $ASSUME_YES -eq 1 ]]; then
+  INTERACTIVE=0
+fi
 
 if [[ -n "$ADMIN_PASSWORD_FILE_ARG" ]]; then
   [[ -r "$ADMIN_PASSWORD_FILE_ARG" ]] || { echo "cannot read $ADMIN_PASSWORD_FILE_ARG" >&2; exit 1; }
@@ -107,10 +150,17 @@ fi
 [[ $EUID -eq 0 ]] || { echo "must run as root (use sudo)" >&2; exit 1; }
 [[ -f "$REPO_DIR/flake.nix" ]] || { echo "no flake.nix at $REPO_DIR" >&2; exit 1; }
 
-command -v lsblk      >/dev/null || { echo "lsblk missing"      >&2; exit 1; }
-command -v git        >/dev/null || { echo "git missing"        >&2; exit 1; }
-command -v nix        >/dev/null || { echo "nix missing"        >&2; exit 1; }
-command -v nixos-install >/dev/null || { echo "nixos-install missing (use the NixOS live USB)" >&2; exit 1; }
+# Required tools. nixos-install only exists on the NixOS live USB, so a missing
+# one is the clearest signal you're not running this where it's meant to run.
+for tool in lsblk openssl git nix nixos-install gum; do
+  command -v "$tool" >/dev/null && continue
+  if [[ "$tool" == "nixos-install" ]]; then
+    echo "nixos-install missing (use the NixOS live USB)" >&2
+  else
+    echo "$tool missing" >&2
+  fi
+  exit 1
+done
 
 # Git complains about repo ownership when running under sudo. Whitelist this
 # repo so subsequent git operations don't refuse to run.
@@ -206,6 +256,28 @@ list_disks() {
     | awk '$4=="disk" && $3=="0" && $1 !~ /\/(zram|dm-|md|loop)[0-9]+$/ { size_h=$2; cmd="numfmt --to=iec --suffix=B "$2; cmd|getline size_h; close(cmd); model=""; for(i=5;i<=NF;i++) model=model (model==""?"":" ") $i; print $1"\t"size_h"\t"model }'
 }
 
+# Interactive UI via gum (charmbracelet) — the modern alternative to the ncurses
+# dialog/whiptail family. gum is baked into the Coder box ISO (see
+# nixos/_images/base/iso.nix) and checked in the preflight tool loop above, so
+# it's a hard requirement: no plain-`read` fallback.
+#
+# Both helpers echo the chosen value on stdout (gum draws its UI on the
+# terminal), so they're safe inside command substitution. Empty input keeps the
+# default.
+prompt_value() {
+  # $1 = label, $2 = default
+  local label="$1" default="$2" reply
+  reply="$(gum input --prompt "$label: " --value "$default")" || reply="$default"
+  printf '%s' "${reply:-$default}"
+}
+
+prompt_secret() {
+  # $1 = label, $2 = default (hidden input; empty keeps the default)
+  local label="$1" default="$2" reply
+  reply="$(gum input --password --prompt "$label (keep default if empty): ")" || reply=""
+  printf '%s' "${reply:-$default}"
+}
+
 # ── Gather inputs ──────────────────────────────────────────────────────────
 # Resolve the build/commit revision for display: prefer git (the normal
 # live-USB clone, or a fork checkout), else the baked /etc/coder-box-rev that
@@ -219,9 +291,17 @@ box_revision() {
 echo "=== Coder NixOS installer ==="
 echo "  revision: $(box_revision)"
 echo
+if [[ $INTERACTIVE -eq 1 ]]; then
+  echo "Interactive mode: press Enter to accept the [default] for any prompt."
+  echo
+fi
 
-# Defaults used when the corresponding flag is omitted.
-DEFAULT_HOSTNAME="coder-nixos"
+# Random 8-char hex suffix so each box gets a unique default hostname
+# (e.g. coder-box-deadbeef), avoiding *.local / mDNS collisions when several
+# boxes are installed with defaults on the same network. openssl ships in the
+# NixOS live environment (and the baked image) alongside the other tools the
+# installer already depends on.
+DEFAULT_HOSTNAME="coder-box-$(openssl rand -hex 4)"
 DEFAULT_ADMIN_EMAIL="admin@coder.com"
 DEFAULT_ADMIN_PASSWORD="PleaseChangeMe1234"
 DEFAULT_NIXOS_USERNAME="coderbox"
@@ -234,62 +314,98 @@ PASSWORD_IS_DEFAULT=0
 NIXOS_USERNAME_IS_DEFAULT=0
 NIXOS_PASSWORD_IS_DEFAULT=0
 
+# Each value falls back to its default unless passed as a flag. In interactive
+# mode we instead prompt (still defaulting on empty input) for any value the
+# user didn't pass on the command line.
 if [[ -z "$HOSTNAME_ARG" ]]; then
-  HOSTNAME_ARG="$DEFAULT_HOSTNAME"
-  HOSTNAME_IS_DEFAULT=1
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    while :; do
+      HOSTNAME_ARG="$(prompt_value "Hostname" "$DEFAULT_HOSTNAME")"
+      validate_hostname "$HOSTNAME_ARG" && break
+    done
+  else
+    HOSTNAME_ARG="$DEFAULT_HOSTNAME"
+  fi
+  [[ "$HOSTNAME_ARG" == "$DEFAULT_HOSTNAME" ]] && HOSTNAME_IS_DEFAULT=1
 fi
 validate_hostname "$HOSTNAME_ARG"
 
 # Hardware description is a free-text comment header. Auto-detected if not
-# given via --hardware-desc.
+# given via --hardware-desc; interactive lets the user override the guess.
 if [[ -z "$HARDWARE_DESC_ARG" ]]; then
   HARDWARE_DESC_ARG="$(detect_hardware_desc)"
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    HARDWARE_DESC_ARG="$(prompt_value "Hardware description" "$HARDWARE_DESC_ARG")"
+  fi
 fi
 
+# Disk has no safe default. Non-interactive runs must pass --disk; interactive
+# runs get the numbered picker below.
 if [[ -z "$DISK_ARG" ]]; then
+  if [[ $INTERACTIVE -ne 1 ]]; then
+    echo "no target disk: pass --disk PATH, or re-run with --interactive to pick one" >&2
+    echo "  (use lsblk to inspect available disks)" >&2
+    exit 1
+  fi
   echo
-  echo "Available disks (non-removable):"
   mapfile -t DISKS < <(list_disks)
   if [[ ${#DISKS[@]} -eq 0 ]]; then
     echo "  no eligible disks found" >&2
     echo "  override with --disk if needed (use lsblk to inspect)" >&2
     exit 1
   fi
-  i=1
-  for d in "${DISKS[@]}"; do
-    printf "  [%d] %s\n" "$i" "$d"
-    i=$((i+1))
-  done
-  echo
-  read -r -p "Install to which disk? [1]: " choice
-  choice="${choice:-1}"
-  [[ "$choice" =~ ^[0-9]+$ && "$choice" -ge 1 && "$choice" -le ${#DISKS[@]} ]] \
-    || { echo "invalid selection: $choice" >&2; exit 1; }
-  DISK_ARG=$(awk '{print $1}' <<<"${DISKS[$((choice-1))]}")
+  sel="$(printf '%s\n' "${DISKS[@]}" \
+    | gum choose --header "Install to which disk? (it WILL be wiped)")" \
+    || { echo "no disk selected" >&2; exit 1; }
+  [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
+  DISK_ARG=$(awk '{print $1}' <<<"$sel")
 fi
 [[ -b "$DISK_ARG" ]] || { echo "not a block device: $DISK_ARG" >&2; exit 1; }
 
 if [[ -z "$ADMIN_EMAIL_ARG" ]]; then
-  ADMIN_EMAIL_ARG="$DEFAULT_ADMIN_EMAIL"
-  EMAIL_IS_DEFAULT=1
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    ADMIN_EMAIL_ARG="$(prompt_value "Coder admin email" "$DEFAULT_ADMIN_EMAIL")"
+  else
+    ADMIN_EMAIL_ARG="$DEFAULT_ADMIN_EMAIL"
+  fi
+  [[ "$ADMIN_EMAIL_ARG" == "$DEFAULT_ADMIN_EMAIL" ]] && EMAIL_IS_DEFAULT=1
 fi
 if [[ -z "$ADMIN_PASSWORD_ARG" ]]; then
-  ADMIN_PASSWORD_ARG="$DEFAULT_ADMIN_PASSWORD"
-  PASSWORD_IS_DEFAULT=1
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    ADMIN_PASSWORD_ARG="$(prompt_secret "Coder admin password" "$DEFAULT_ADMIN_PASSWORD")"
+  else
+    ADMIN_PASSWORD_ARG="$DEFAULT_ADMIN_PASSWORD"
+  fi
+  [[ "$ADMIN_PASSWORD_ARG" == "$DEFAULT_ADMIN_PASSWORD" ]] && PASSWORD_IS_DEFAULT=1
 fi
 
 if [[ -z "$NIXOS_USERNAME_ARG" ]]; then
-  NIXOS_USERNAME_ARG="$DEFAULT_NIXOS_USERNAME"
-  NIXOS_USERNAME_IS_DEFAULT=1
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    while :; do
+      NIXOS_USERNAME_ARG="$(prompt_value "NixOS login user" "$DEFAULT_NIXOS_USERNAME")"
+      validate_username "$NIXOS_USERNAME_ARG" && break
+    done
+  else
+    NIXOS_USERNAME_ARG="$DEFAULT_NIXOS_USERNAME"
+  fi
+  [[ "$NIXOS_USERNAME_ARG" == "$DEFAULT_NIXOS_USERNAME" ]] && NIXOS_USERNAME_IS_DEFAULT=1
 fi
 validate_username "$NIXOS_USERNAME_ARG"
 if [[ -z "$NIXOS_PASSWORD_ARG" ]]; then
-  NIXOS_PASSWORD_ARG="$DEFAULT_NIXOS_PASSWORD"
-  NIXOS_PASSWORD_IS_DEFAULT=1
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    NIXOS_PASSWORD_ARG="$(prompt_secret "NixOS login password" "$DEFAULT_NIXOS_PASSWORD")"
+  else
+    NIXOS_PASSWORD_ARG="$DEFAULT_NIXOS_PASSWORD"
+  fi
+  [[ "$NIXOS_PASSWORD_ARG" == "$DEFAULT_NIXOS_PASSWORD" ]] && NIXOS_PASSWORD_IS_DEFAULT=1
 fi
 
 if [[ -z "$LAN_IP_ARG" ]]; then
   LAN_IP_ARG=$(detect_lan_ip || true)
+  if [[ $INTERACTIVE -eq 1 ]]; then
+    LAN_IP_ARG="$(prompt_value "LAN IP" "${LAN_IP_ARG:-none}")"
+    [[ "$LAN_IP_ARG" == "none" ]] && LAN_IP_ARG=""
+  fi
 fi
 
 # Existing host folder?
@@ -332,8 +448,9 @@ fi
 echo
 
 if [[ $ASSUME_YES -eq 0 ]]; then
-  read -r -p "Wipe $DISK_ARG and install? [y/N]: " ans
-  case "${ans,,}" in y|yes) ;; *) echo "aborted." >&2; exit 1 ;; esac
+  # --default=false so the destructive action isn't the pre-selected button.
+  gum confirm --default=false "Wipe $DISK_ARG and install?" \
+    || { echo "aborted." >&2; exit 1; }
 fi
 
 # ── Generate host files ────────────────────────────────────────────────────
@@ -538,7 +655,6 @@ if [[ $NO_REBOOT -eq 0 ]]; then
     sleep 5
     reboot
   else
-    read -r -p "Reboot now? [Y/n]: " ans
-    case "${ans,,}" in n|no) echo "skip reboot." ;; *) reboot ;; esac
+    if gum confirm "Reboot now?"; then reboot; else echo "skip reboot."; fi
   fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -76,14 +76,6 @@ UNSAFE_ASSUME_DISK=0
 
 usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \?//; s/^set -euo.*//' | sed '/^$/N;/^\n$/D'; }
 
-# Require a value for a value-taking flag. Without this, a flag passed as the
-# last token with no argument (e.g. `--coder-admin-password`) expands `$2` under
-# `set -u` and crashes with "$2: unbound variable" instead of a clear message.
-# (GNU getopt already guarantees a value token, but this guard is cheap.)
-need_value() {
-  [[ $# -ge 2 ]] || { echo "flag $1 requires a value" >&2; usage >&2; exit 2; }
-}
-
 # Option spec for getopt.
 SHORT_OPTS="iyh"
 LONG_OPTS="hostname:,hardware-desc:,disk:,coder-admin-email:,coder-admin-password:"
@@ -110,16 +102,16 @@ eval set -- "$PARSED"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --hostname)              need_value "$@"; HOSTNAME_ARG="$2";              shift 2 ;;
-    --hardware-desc)         need_value "$@"; HARDWARE_DESC_ARG="$2";         shift 2 ;;
-    --disk)                  need_value "$@"; DISK_ARG="$2";                  shift 2 ;;
-    --coder-admin-email)           need_value "$@"; ADMIN_EMAIL_ARG="$2";           shift 2 ;;
-    --coder-admin-password)        need_value "$@"; ADMIN_PASSWORD_ARG="$2";        shift 2 ;;
-    --coder-admin-password-file)   need_value "$@"; ADMIN_PASSWORD_FILE_ARG="$2";   shift 2 ;;
-    --nixos-username)        need_value "$@"; NIXOS_USERNAME_ARG="$2";        shift 2 ;;
-    --nixos-password)        need_value "$@"; NIXOS_PASSWORD_ARG="$2";        shift 2 ;;
-    --nixos-password-file)   need_value "$@"; NIXOS_PASSWORD_FILE_ARG="$2";   shift 2 ;;
-    --lan-ip)                need_value "$@"; LAN_IP_ARG="$2";                shift 2 ;;
+    --hostname)              HOSTNAME_ARG="$2";              shift 2 ;;
+    --hardware-desc)         HARDWARE_DESC_ARG="$2";         shift 2 ;;
+    --disk)                  DISK_ARG="$2";                  shift 2 ;;
+    --coder-admin-email)           ADMIN_EMAIL_ARG="$2";           shift 2 ;;
+    --coder-admin-password)        ADMIN_PASSWORD_ARG="$2";        shift 2 ;;
+    --coder-admin-password-file)   ADMIN_PASSWORD_FILE_ARG="$2";   shift 2 ;;
+    --nixos-username)        NIXOS_USERNAME_ARG="$2";        shift 2 ;;
+    --nixos-password)        NIXOS_PASSWORD_ARG="$2";        shift 2 ;;
+    --nixos-password-file)   NIXOS_PASSWORD_FILE_ARG="$2";   shift 2 ;;
+    --lan-ip)                LAN_IP_ARG="$2";                shift 2 ;;
     --no-reboot)             NO_REBOOT=1;                    shift ;;
     --interactive|-i)        INTERACTIVE=1;                  shift ;;
     --unsafe-assume-disk)    UNSAFE_ASSUME_DISK=1;           shift ;;

--- a/install.sh
+++ b/install.sh
@@ -453,6 +453,7 @@ if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
 else
   printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
+printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 printf "  NixOS login user:     %s%s\n" "$NIXOS_USERNAME_ARG" \
   "$( [[ $NIXOS_USERNAME_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
 if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
@@ -460,7 +461,6 @@ if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
 else
   printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
-printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 if [[ $HOSTNAME_IS_DEFAULT -eq 1 || $EMAIL_IS_DEFAULT -eq 1 || $PASSWORD_IS_DEFAULT -eq 1 \
    || $NIXOS_USERNAME_IS_DEFAULT -eq 1 || $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
   echo
@@ -655,13 +655,13 @@ if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
 else
   printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
+printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 printf "  NixOS login user:     %s\n" "$NIXOS_USERNAME_ARG"
 if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
   printf "  NixOS login password: %s  (default)\n" "$NIXOS_PASSWORD_ARG"
 else
   printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
-printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 echo
 echo "Coder web UI after reboot:"
 echo "  http://${HOSTNAME_ARG}.local        (port 80 redirects to the *.try.coder.app tunnel URL)"

--- a/install.sh
+++ b/install.sh
@@ -152,7 +152,11 @@ fi
 
 # Required tools. nixos-install only exists on the NixOS live USB, so a missing
 # one is the clearest signal you're not running this where it's meant to run.
-for tool in lsblk openssl git nix nixos-install gum; do
+# gum only drives the interactive prompts, so it's only required with
+# --interactive.
+REQUIRED_TOOLS=(lsblk openssl git nix nixos-install)
+[[ $INTERACTIVE -eq 1 ]] && REQUIRED_TOOLS+=(gum)
+for tool in "${REQUIRED_TOOLS[@]}"; do
   command -v "$tool" >/dev/null && continue
   if [[ "$tool" == "nixos-install" ]]; then
     echo "nixos-install missing (use the NixOS live USB)" >&2
@@ -258,24 +262,31 @@ list_disks() {
 
 # Interactive UI via gum (charmbracelet) — the modern alternative to the ncurses
 # dialog/whiptail family. gum is baked into the Coder box ISO (see
-# nixos/_images/base/iso.nix) and checked in the preflight tool loop above, so
-# it's a hard requirement: no plain-`read` fallback.
+# nixos/_images/base/iso.nix) and checked in the preflight tool loop (only when
+# --interactive is passed), so it's a hard requirement there: no plain-`read`
+# fallback.
 #
 # Both helpers echo the chosen value on stdout (gum draws its UI on the
 # terminal), so they're safe inside command substitution. Empty input keeps the
-# default.
+# default. gum clears its widget after submit, so we echo the question and the
+# resolved answer to the terminal (stderr) afterwards to leave a visible record.
 prompt_value() {
   # $1 = label, $2 = default
   local label="$1" default="$2" reply
   reply="$(gum input --prompt "$label: " --value "$default")" || reply="$default"
-  printf '%s' "${reply:-$default}"
+  reply="${reply:-$default}"
+  echo "  $label: $reply" >&2
+  printf '%s' "$reply"
 }
 
 prompt_secret() {
   # $1 = label, $2 = default (hidden input; empty keeps the default)
   local label="$1" default="$2" reply
   reply="$(gum input --password --prompt "$label (keep default if empty): ")" || reply=""
-  printf '%s' "${reply:-$default}"
+  reply="${reply:-$default}"
+  # Don't echo the secret itself; just confirm it was set.
+  echo "  $label: ${reply:+(set)}" >&2
+  printf '%s' "$reply"
 }
 
 # Resolve a single input variable in place, centralising the "flag wins, else
@@ -384,16 +395,22 @@ if [[ -z "$DISK_ARG" ]]; then
   fi
   echo
   mapfile -t DISKS < <(list_disks)
-  if [[ ${#DISKS[@]} -eq 0 ]]; then
-    echo "  no eligible disks found" >&2
-    echo "  override with --disk if needed (use lsblk to inspect)" >&2
-    exit 1
-  fi
-  sel="$(printf '%s\n' "${DISKS[@]}" \
+  # Always offer "Other …" so a user can type a path the auto-detection missed
+  # (unusual controllers, /dev/mapper, etc.); it's the only choice when no
+  # eligible disks were found.
+  OTHER_LABEL="Other (enter a disk path manually)"
+  sel="$(printf '%s\n' "${DISKS[@]}" "$OTHER_LABEL" \
     | gum choose --header "Install to which disk? (it WILL be wiped)")" \
     || { echo "no disk selected" >&2; exit 1; }
   [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
-  DISK_ARG=$(awk '{print $1}' <<<"$sel")
+  if [[ "$sel" == "$OTHER_LABEL" ]]; then
+    DISK_ARG="$(gum input --prompt "Disk path: " --placeholder "/dev/sda")" \
+      || { echo "no disk entered" >&2; exit 1; }
+  else
+    DISK_ARG=$(awk '{print $1}' <<<"$sel")
+  fi
+  # gum clears its widget after submit; echo the choice so it stays on screen.
+  echo "  Install to disk: $DISK_ARG" >&2
 fi
 [[ -b "$DISK_ARG" ]] || { echo "not a block device: $DISK_ARG" >&2; exit 1; }
 

--- a/install.sh
+++ b/install.sh
@@ -278,6 +278,55 @@ prompt_secret() {
   printf '%s' "${reply:-$default}"
 }
 
+# Resolve a single input variable in place, centralising the "flag wins, else
+# prompt (interactive) or default (unattended)" logic so each input is one call
+# instead of a repeated if/else block.
+#
+#   resolve_value VARNAME LABEL DEFAULT [--secret] [--validate FN] [--default-flag FLAGVAR]
+#
+#   - VARNAME already set (passed as a flag) → keep it untouched.
+#   - else interactive            → prompt (re-prompting until --validate FN passes).
+#   - else unattended             → use DEFAULT.
+#   - --secret                    → hidden (password) prompt; empty keeps DEFAULT.
+#   - --default-flag FLAGVAR      → set FLAGVAR=1 when the resolved value equals
+#                                   DEFAULT, so the summary can mark it.
+#
+# Validation of flag-passed values stays at the call site (so an invalid flag
+# value errors out the same as before).
+resolve_value() {
+  local -n _rv_var="$1"
+  local label="$2" default="$3"; shift 3
+  local secret=0 validate="" flagname=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --secret)       secret=1;        shift ;;
+      --validate)     validate="$2";   shift 2 ;;
+      --default-flag) flagname="$2";   shift 2 ;;
+      *) echo "resolve_value: unknown option $1" >&2; exit 2 ;;
+    esac
+  done
+
+  if [[ -z "$_rv_var" ]]; then
+    if [[ $INTERACTIVE -eq 1 ]]; then
+      while :; do
+        if [[ $secret -eq 1 ]]; then
+          _rv_var="$(prompt_secret "$label" "$default")"
+        else
+          _rv_var="$(prompt_value "$label" "$default")"
+        fi
+        [[ -z "$validate" ]] && break
+        "$validate" "$_rv_var" && break
+      done
+    else
+      _rv_var="$default"
+    fi
+    if [[ -n "$flagname" && "$_rv_var" == "$default" ]]; then
+      local -n _rv_flag="$flagname"
+      _rv_flag=1
+    fi
+  fi
+}
+
 # ── Gather inputs ──────────────────────────────────────────────────────────
 # Resolve the build/commit revision for display: prefer git (the normal
 # live-USB clone, or a fork checkout), else the baked /etc/coder-box-rev that
@@ -314,30 +363,16 @@ PASSWORD_IS_DEFAULT=0
 NIXOS_USERNAME_IS_DEFAULT=0
 NIXOS_PASSWORD_IS_DEFAULT=0
 
-# Each value falls back to its default unless passed as a flag. In interactive
-# mode we instead prompt (still defaulting on empty input) for any value the
-# user didn't pass on the command line.
-if [[ -z "$HOSTNAME_ARG" ]]; then
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    while :; do
-      HOSTNAME_ARG="$(prompt_value "Hostname" "$DEFAULT_HOSTNAME")"
-      validate_hostname "$HOSTNAME_ARG" && break
-    done
-  else
-    HOSTNAME_ARG="$DEFAULT_HOSTNAME"
-  fi
-  [[ "$HOSTNAME_ARG" == "$DEFAULT_HOSTNAME" ]] && HOSTNAME_IS_DEFAULT=1
-fi
+# Each value falls back to its default unless passed as a flag; in interactive
+# mode we prompt instead (see resolve_value). Validation of flag-passed values
+# still runs unconditionally after each call.
+resolve_value HOSTNAME_ARG "Hostname" "$DEFAULT_HOSTNAME" \
+  --validate validate_hostname --default-flag HOSTNAME_IS_DEFAULT
 validate_hostname "$HOSTNAME_ARG"
 
-# Hardware description is a free-text comment header. Auto-detected if not
-# given via --hardware-desc; interactive lets the user override the guess.
-if [[ -z "$HARDWARE_DESC_ARG" ]]; then
-  HARDWARE_DESC_ARG="$(detect_hardware_desc)"
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    HARDWARE_DESC_ARG="$(prompt_value "Hardware description" "$HARDWARE_DESC_ARG")"
-  fi
-fi
+# Hardware description is a free-text comment header. The auto-detected value is
+# the default (and the interactive prompt's prefill); --hardware-desc overrides.
+resolve_value HARDWARE_DESC_ARG "Hardware description" "$(detect_hardware_desc)"
 
 # Disk has no safe default. Non-interactive runs must pass --disk; interactive
 # runs get the numbered picker below.
@@ -362,51 +397,22 @@ if [[ -z "$DISK_ARG" ]]; then
 fi
 [[ -b "$DISK_ARG" ]] || { echo "not a block device: $DISK_ARG" >&2; exit 1; }
 
-if [[ -z "$ADMIN_EMAIL_ARG" ]]; then
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    ADMIN_EMAIL_ARG="$(prompt_value "Coder admin email" "$DEFAULT_ADMIN_EMAIL")"
-  else
-    ADMIN_EMAIL_ARG="$DEFAULT_ADMIN_EMAIL"
-  fi
-  [[ "$ADMIN_EMAIL_ARG" == "$DEFAULT_ADMIN_EMAIL" ]] && EMAIL_IS_DEFAULT=1
-fi
-if [[ -z "$ADMIN_PASSWORD_ARG" ]]; then
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    ADMIN_PASSWORD_ARG="$(prompt_secret "Coder admin password" "$DEFAULT_ADMIN_PASSWORD")"
-  else
-    ADMIN_PASSWORD_ARG="$DEFAULT_ADMIN_PASSWORD"
-  fi
-  [[ "$ADMIN_PASSWORD_ARG" == "$DEFAULT_ADMIN_PASSWORD" ]] && PASSWORD_IS_DEFAULT=1
-fi
+resolve_value ADMIN_EMAIL_ARG "Coder admin email" "$DEFAULT_ADMIN_EMAIL" \
+  --default-flag EMAIL_IS_DEFAULT
+resolve_value ADMIN_PASSWORD_ARG "Coder admin password" "$DEFAULT_ADMIN_PASSWORD" \
+  --secret --default-flag PASSWORD_IS_DEFAULT
 
-if [[ -z "$NIXOS_USERNAME_ARG" ]]; then
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    while :; do
-      NIXOS_USERNAME_ARG="$(prompt_value "NixOS login user" "$DEFAULT_NIXOS_USERNAME")"
-      validate_username "$NIXOS_USERNAME_ARG" && break
-    done
-  else
-    NIXOS_USERNAME_ARG="$DEFAULT_NIXOS_USERNAME"
-  fi
-  [[ "$NIXOS_USERNAME_ARG" == "$DEFAULT_NIXOS_USERNAME" ]] && NIXOS_USERNAME_IS_DEFAULT=1
-fi
+resolve_value NIXOS_USERNAME_ARG "NixOS login user" "$DEFAULT_NIXOS_USERNAME" \
+  --validate validate_username --default-flag NIXOS_USERNAME_IS_DEFAULT
 validate_username "$NIXOS_USERNAME_ARG"
-if [[ -z "$NIXOS_PASSWORD_ARG" ]]; then
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    NIXOS_PASSWORD_ARG="$(prompt_secret "NixOS login password" "$DEFAULT_NIXOS_PASSWORD")"
-  else
-    NIXOS_PASSWORD_ARG="$DEFAULT_NIXOS_PASSWORD"
-  fi
-  [[ "$NIXOS_PASSWORD_ARG" == "$DEFAULT_NIXOS_PASSWORD" ]] && NIXOS_PASSWORD_IS_DEFAULT=1
-fi
+resolve_value NIXOS_PASSWORD_ARG "NixOS login password" "$DEFAULT_NIXOS_PASSWORD" \
+  --secret --default-flag NIXOS_PASSWORD_IS_DEFAULT
 
-if [[ -z "$LAN_IP_ARG" ]]; then
-  LAN_IP_ARG=$(detect_lan_ip || true)
-  if [[ $INTERACTIVE -eq 1 ]]; then
-    LAN_IP_ARG="$(prompt_value "LAN IP" "${LAN_IP_ARG:-none}")"
-    [[ "$LAN_IP_ARG" == "none" ]] && LAN_IP_ARG=""
-  fi
-fi
+# LAN IP: the auto-detected value is the default ("none" when nothing detected,
+# which we map back to empty so downstream treats it as "no IP detected").
+LAN_IP_DEFAULT="$(detect_lan_ip || true)"
+resolve_value LAN_IP_ARG "LAN IP" "${LAN_IP_DEFAULT:-none}"
+[[ "$LAN_IP_ARG" == "none" ]] && LAN_IP_ARG=""
 
 # Existing host folder?
 HOST_DIR="$REPO_DIR/hosts/$HOSTNAME_ARG"

--- a/install.sh
+++ b/install.sh
@@ -412,7 +412,13 @@ if [[ -z "$DISK_ARG" ]]; then
     || { echo "no disk selected" >&2; exit 1; }
   [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
   if [[ "$sel" == "$OTHER_LABEL" ]]; then
-    DISK_ARG="$(gum input --prompt "Disk path: " --placeholder "/dev/sda")" \
+    # Prefill with the main guessed disk (first detected) so the user can edit a
+    # near-correct path instead of typing from scratch; fall back to a hint when
+    # nothing was detected.
+    guessed_disk=""
+    [[ ${#DISKS[@]} -gt 0 ]] && guessed_disk="$(awk '{print $1}' <<<"${DISKS[0]}")"
+    DISK_ARG="$(gum input --prompt "Disk path: " \
+      --value "$guessed_disk" --placeholder "/dev/sda")" \
       || { echo "no disk entered" >&2; exit 1; }
   else
     DISK_ARG=$(awk '{print $1}' <<<"$sel")

--- a/install.sh
+++ b/install.sh
@@ -451,27 +451,48 @@ if [[ -d "$HOST_DIR" ]]; then
 fi
 
 # ── Summary + confirm ──────────────────────────────────────────────────────
+# Shared summary printer for both the pre-install ("ready") and post-install
+# ("installed") views. They differ only in: the "ready" view shows the hardware
+# line, labels the disk "(will wipe)", and flags values left at their defaults.
+# Passwords are masked unless they're the well-known default (shown so the user
+# knows it's in use).
+print_summary() {
+  local mode="$1"
+  local row="  %-21s %s\n"
+  local disk_label="Disk:" mark_host="" mark_email="" mark_user=""
+  if [[ "$mode" == "ready" ]]; then
+    disk_label="Disk (will wipe):"
+    [[ $HOSTNAME_IS_DEFAULT       -eq 1 ]] && mark_host="  (default)"
+    [[ $EMAIL_IS_DEFAULT          -eq 1 ]] && mark_email="  (default)"
+    [[ $NIXOS_USERNAME_IS_DEFAULT -eq 1 ]] && mark_user="  (default)"
+  fi
+  local masked_nixos_pw masked_admin_pw
+  masked_nixos_pw="$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
+  masked_admin_pw="$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
+
+  # shellcheck disable=SC2059  # $row is an intentional, fixed format string.
+  printf "$row" "Hostname:" "$HOSTNAME_ARG$mark_host"
+  [[ "$mode" == "ready" ]] && printf "$row" "Hardware:" "$HARDWARE_DESC_ARG"
+  printf "$row" "$disk_label" "$DISK_ARG"
+  printf "$row" "LAN IP:" "${LAN_IP_ARG:-(none detected)}"
+  printf "$row" "NixOS login user:" "$NIXOS_USERNAME_ARG$mark_user"
+  if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
+    printf "$row" "NixOS login password:" "$NIXOS_PASSWORD_ARG  (default)"
+  else
+    printf "$row" "NixOS login password:" "$masked_nixos_pw"
+  fi
+  printf "$row" "Coder admin email:" "$ADMIN_EMAIL_ARG$mark_email"
+  if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
+    printf "$row" "Coder admin password:" "$ADMIN_PASSWORD_ARG  (default)"
+  else
+    printf "$row" "Coder admin password:" "$masked_admin_pw"
+  fi
+}
+
 echo
+echo "────────────────────────────────────────────────────────────"
 echo "Ready to install:"
-printf "  Hostname:             %s%s\n" "$HOSTNAME_ARG" \
-  "$( [[ $HOSTNAME_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
-printf "  Hardware:             %s\n" "$HARDWARE_DESC_ARG"
-printf "  Disk (will wipe):     %s\n" "$DISK_ARG"
-printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
-printf "  NixOS login user:     %s%s\n" "$NIXOS_USERNAME_ARG" \
-  "$( [[ $NIXOS_USERNAME_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
-if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  NixOS login password: %s  (default)\n" "$NIXOS_PASSWORD_ARG"
-else
-  printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
-printf "  Coder admin email:    %s%s\n" "$ADMIN_EMAIL_ARG" \
-  "$( [[ $EMAIL_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
-if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
-else
-  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
+print_summary ready
 if [[ $HOSTNAME_IS_DEFAULT -eq 1 || $EMAIL_IS_DEFAULT -eq 1 || $PASSWORD_IS_DEFAULT -eq 1 \
    || $NIXOS_USERNAME_IS_DEFAULT -eq 1 || $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
   echo
@@ -658,21 +679,7 @@ echo
 echo "✓ Installation complete."
 echo
 echo "Installed:"
-printf "  Hostname:             %s\n" "$HOSTNAME_ARG"
-printf "  Disk:                 %s\n" "$DISK_ARG"
-printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
-printf "  NixOS login user:     %s\n" "$NIXOS_USERNAME_ARG"
-if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  NixOS login password: %s  (default)\n" "$NIXOS_PASSWORD_ARG"
-else
-  printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
-printf "  Coder admin email:    %s\n" "$ADMIN_EMAIL_ARG"
-if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
-else
-  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
+print_summary installed
 echo
 echo "Coder web UI after reboot:"
 echo "  http://${HOSTNAME_ARG}.local        (port 80 redirects to the *.try.coder.app tunnel URL)"

--- a/install.sh
+++ b/install.sh
@@ -397,22 +397,20 @@ if [[ -z "$DISK_ARG" ]]; then
   mapfile -t DISKS < <(list_disks)
   # Always offer "Other …" so a user can type a path the auto-detection missed
   # (unusual controllers, /dev/mapper, etc.); it's the only choice when no
-  # eligible disks were found.
-  OTHER_LABEL="Other (enter a disk path manually)"
-  SEP_LABEL="──────────"
-  # Build the choice list: detected disks, a separator (only when there are
-  # disks to separate from), then "Other".
-  CHOICES=("${DISKS[@]}")
-  [[ ${#DISKS[@]} -gt 0 ]] && CHOICES+=("$SEP_LABEL")
-  CHOICES+=("$OTHER_LABEL")
-  while :; do
-    sel="$(printf '%s\n' "${CHOICES[@]}" \
-      | gum choose --header "Install to which disk? (it WILL be wiped)")" \
-      || { echo "no disk selected" >&2; exit 1; }
-    [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
-    # The separator is decorative; re-prompt if it's picked.
-    [[ "$sel" == "$SEP_LABEL" ]] || break
-  done
+  # eligible disks were found. gum choose has no non-selectable rows, so instead
+  # of a separate divider line (which would be focusable), the divider is fused
+  # into the "Other" label — it stands apart visually but isn't its own pickable
+  # item. The leading divider is only shown when there are disks to separate from.
+  OTHER_TEXT="Other (enter a disk path manually)"
+  if [[ ${#DISKS[@]} -gt 0 ]]; then
+    OTHER_LABEL="────────  $OTHER_TEXT"
+  else
+    OTHER_LABEL="$OTHER_TEXT"
+  fi
+  sel="$(printf '%s\n' "${DISKS[@]}" "$OTHER_LABEL" \
+    | gum choose --header "Install to which disk? (it WILL be wiped)")" \
+    || { echo "no disk selected" >&2; exit 1; }
+  [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
   if [[ "$sel" == "$OTHER_LABEL" ]]; then
     DISK_ARG="$(gum input --prompt "Disk path: " --placeholder "/dev/sda")" \
       || { echo "no disk entered" >&2; exit 1; }
@@ -424,10 +422,14 @@ if [[ -z "$DISK_ARG" ]]; then
 fi
 [[ -b "$DISK_ARG" ]] || { echo "not a block device: $DISK_ARG" >&2; exit 1; }
 
-resolve_value ADMIN_EMAIL_ARG "Coder admin email" "$DEFAULT_ADMIN_EMAIL" \
-  --default-flag EMAIL_IS_DEFAULT
-resolve_value ADMIN_PASSWORD_ARG "Coder admin password" "$DEFAULT_ADMIN_PASSWORD" \
-  --secret --default-flag PASSWORD_IS_DEFAULT
+# Prompt order mirrors the summary/log ordering: LAN IP, NixOS login creds,
+# then Coder admin creds.
+#
+# LAN IP: the auto-detected value is the default ("none" when nothing detected,
+# which we map back to empty so downstream treats it as "no IP detected").
+LAN_IP_DEFAULT="$(detect_lan_ip || true)"
+resolve_value LAN_IP_ARG "LAN IP" "${LAN_IP_DEFAULT:-none}"
+[[ "$LAN_IP_ARG" == "none" ]] && LAN_IP_ARG=""
 
 resolve_value NIXOS_USERNAME_ARG "NixOS login user" "$DEFAULT_NIXOS_USERNAME" \
   --validate validate_username --default-flag NIXOS_USERNAME_IS_DEFAULT
@@ -435,11 +437,10 @@ validate_username "$NIXOS_USERNAME_ARG"
 resolve_value NIXOS_PASSWORD_ARG "NixOS login password" "$DEFAULT_NIXOS_PASSWORD" \
   --secret --default-flag NIXOS_PASSWORD_IS_DEFAULT
 
-# LAN IP: the auto-detected value is the default ("none" when nothing detected,
-# which we map back to empty so downstream treats it as "no IP detected").
-LAN_IP_DEFAULT="$(detect_lan_ip || true)"
-resolve_value LAN_IP_ARG "LAN IP" "${LAN_IP_DEFAULT:-none}"
-[[ "$LAN_IP_ARG" == "none" ]] && LAN_IP_ARG=""
+resolve_value ADMIN_EMAIL_ARG "Coder admin email" "$DEFAULT_ADMIN_EMAIL" \
+  --default-flag EMAIL_IS_DEFAULT
+resolve_value ADMIN_PASSWORD_ARG "Coder admin password" "$DEFAULT_ADMIN_PASSWORD" \
+  --secret --default-flag PASSWORD_IS_DEFAULT
 
 # Existing host folder?
 HOST_DIR="$REPO_DIR/hosts/$HOSTNAME_ARG"

--- a/install.sh
+++ b/install.sh
@@ -446,13 +446,6 @@ printf "  Hostname:             %s%s\n" "$HOSTNAME_ARG" \
   "$( [[ $HOSTNAME_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
 printf "  Hardware:             %s\n" "$HARDWARE_DESC_ARG"
 printf "  Disk (will wipe):     %s\n" "$DISK_ARG"
-printf "  Coder admin email:    %s%s\n" "$ADMIN_EMAIL_ARG" \
-  "$( [[ $EMAIL_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
-if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
-else
-  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
 printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 printf "  NixOS login user:     %s%s\n" "$NIXOS_USERNAME_ARG" \
   "$( [[ $NIXOS_USERNAME_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
@@ -460,6 +453,13 @@ if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
   printf "  NixOS login password: %s  (default)\n" "$NIXOS_PASSWORD_ARG"
 else
   printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
+fi
+printf "  Coder admin email:    %s%s\n" "$ADMIN_EMAIL_ARG" \
+  "$( [[ $EMAIL_IS_DEFAULT -eq 1 ]] && echo '  (default)' )"
+if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
+  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
+else
+  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
 if [[ $HOSTNAME_IS_DEFAULT -eq 1 || $EMAIL_IS_DEFAULT -eq 1 || $PASSWORD_IS_DEFAULT -eq 1 \
    || $NIXOS_USERNAME_IS_DEFAULT -eq 1 || $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
@@ -649,18 +649,18 @@ echo
 echo "Installed:"
 printf "  Hostname:             %s\n" "$HOSTNAME_ARG"
 printf "  Disk:                 %s\n" "$DISK_ARG"
-printf "  Coder admin email:    %s\n" "$ADMIN_EMAIL_ARG"
-if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
-  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
-else
-  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
-fi
 printf "  LAN IP:               %s\n" "${LAN_IP_ARG:-(none detected)}"
 printf "  NixOS login user:     %s\n" "$NIXOS_USERNAME_ARG"
 if [[ $NIXOS_PASSWORD_IS_DEFAULT -eq 1 ]]; then
   printf "  NixOS login password: %s  (default)\n" "$NIXOS_PASSWORD_ARG"
 else
   printf "  NixOS login password: %s\n" "$(printf '%*s' "${#NIXOS_PASSWORD_ARG}" '' | tr ' ' '*')"
+fi
+printf "  Coder admin email:    %s\n" "$ADMIN_EMAIL_ARG"
+if [[ $PASSWORD_IS_DEFAULT -eq 1 ]]; then
+  printf "  Coder admin password: %s  (default)\n" "$ADMIN_PASSWORD_ARG"
+else
+  printf "  Coder admin password: %s\n" "$(printf '%*s' "${#ADMIN_PASSWORD_ARG}" '' | tr ' ' '*')"
 fi
 echo
 echo "Coder web UI after reboot:"

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,8 @@
 #   --no-reboot                      skip the final reboot
 #   --interactive, -i                prompt for any value not passed as a flag
 #                                    (ignored when --yes is given)
+#   --unsafe-assume-disk             when no --disk is given (non-interactive),
+#                                    auto-pick the first detected disk and WIPE it
 #   --yes, -y                        skip the destructive-wipe confirmation
 #   --help, -h                       show this help
 
@@ -70,6 +72,7 @@ LAN_IP_ARG=""
 NO_REBOOT=0
 ASSUME_YES=0
 INTERACTIVE=0
+UNSAFE_ASSUME_DISK=0
 
 usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \?//; s/^set -euo.*//' | sed '/^$/N;/^\n$/D'; }
 
@@ -85,7 +88,7 @@ need_value() {
 SHORT_OPTS="iyh"
 LONG_OPTS="hostname:,hardware-desc:,disk:,coder-admin-email:,coder-admin-password:"
 LONG_OPTS+=",coder-admin-password-file:,nixos-username:,nixos-password:,nixos-password-file:"
-LONG_OPTS+=",lan-ip:,no-reboot,interactive,yes,help"
+LONG_OPTS+=",lan-ip:,no-reboot,interactive,unsafe-assume-disk,yes,help"
 
 # We rely on GNU getopt to normalise `--flag=value`, bundled short flags, and
 # option order into a canonical token stream terminated by `--`. BSD/macOS
@@ -119,6 +122,7 @@ while [[ $# -gt 0 ]]; do
     --lan-ip)                need_value "$@"; LAN_IP_ARG="$2";                shift 2 ;;
     --no-reboot)             NO_REBOOT=1;                    shift ;;
     --interactive|-i)        INTERACTIVE=1;                  shift ;;
+    --unsafe-assume-disk)    UNSAFE_ASSUME_DISK=1;           shift ;;
     --yes|-y)                ASSUME_YES=1;                   shift ;;
     --help|-h)               usage; exit 0 ;;
     --) shift; break ;;
@@ -385,14 +389,28 @@ validate_hostname "$HOSTNAME_ARG"
 # the default (and the interactive prompt's prefill); --hardware-desc overrides.
 resolve_value HARDWARE_DESC_ARG "Hardware description" "$(detect_hardware_desc)"
 
-# Disk has no safe default. Non-interactive runs must pass --disk; interactive
-# runs get the numbered picker below.
+# Disk has no safe default. Non-interactive runs must pass --disk (or opt into
+# --unsafe-assume-disk to auto-pick the first detected disk); interactive runs
+# get the picker below.
 if [[ -z "$DISK_ARG" ]]; then
   if [[ $INTERACTIVE -ne 1 ]]; then
-    echo "no target disk: pass --disk PATH, or re-run with --interactive to pick one" >&2
-    echo "  (use lsblk to inspect available disks)" >&2
-    exit 1
+    if [[ $UNSAFE_ASSUME_DISK -eq 1 ]]; then
+      # Caller explicitly accepted the risk: assume the first auto-detected disk
+      # without confirmation. This WILL be wiped, so it's gated behind the
+      # scary-named flag.
+      mapfile -t DISKS < <(list_disks)
+      [[ ${#DISKS[@]} -gt 0 ]] || { echo "--unsafe-assume-disk: no eligible disk detected" >&2; exit 1; }
+      DISK_ARG=$(awk '{print $1}' <<<"${DISKS[0]}")
+      echo "--unsafe-assume-disk: assuming $DISK_ARG" >&2
+    else
+      echo "no target disk: pass --disk PATH, or re-run with --interactive to pick one" >&2
+      echo "  (or --unsafe-assume-disk to auto-pick the first detected disk)" >&2
+      echo "  (use lsblk to inspect available disks)" >&2
+      exit 1
+    fi
   fi
+fi
+if [[ -z "$DISK_ARG" && $INTERACTIVE -eq 1 ]]; then
   echo
   mapfile -t DISKS < <(list_disks)
   # Always offer "Other …" so a user can type a path the auto-detection missed

--- a/install.sh
+++ b/install.sh
@@ -399,10 +399,20 @@ if [[ -z "$DISK_ARG" ]]; then
   # (unusual controllers, /dev/mapper, etc.); it's the only choice when no
   # eligible disks were found.
   OTHER_LABEL="Other (enter a disk path manually)"
-  sel="$(printf '%s\n' "${DISKS[@]}" "$OTHER_LABEL" \
-    | gum choose --header "Install to which disk? (it WILL be wiped)")" \
-    || { echo "no disk selected" >&2; exit 1; }
-  [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
+  SEP_LABEL="──────────"
+  # Build the choice list: detected disks, a separator (only when there are
+  # disks to separate from), then "Other".
+  CHOICES=("${DISKS[@]}")
+  [[ ${#DISKS[@]} -gt 0 ]] && CHOICES+=("$SEP_LABEL")
+  CHOICES+=("$OTHER_LABEL")
+  while :; do
+    sel="$(printf '%s\n' "${CHOICES[@]}" \
+      | gum choose --header "Install to which disk? (it WILL be wiped)")" \
+      || { echo "no disk selected" >&2; exit 1; }
+    [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
+    # The separator is decorative; re-prompt if it's picked.
+    [[ "$sel" == "$SEP_LABEL" ]] || break
+  done
   if [[ "$sel" == "$OTHER_LABEL" ]]; then
     DISK_ARG="$(gum input --prompt "Disk path: " --placeholder "/dev/sda")" \
       || { echo "no disk entered" >&2; exit 1; }

--- a/install.sh
+++ b/install.sh
@@ -413,33 +413,31 @@ fi
 if [[ -z "$DISK_ARG" && $INTERACTIVE -eq 1 ]]; then
   echo
   mapfile -t DISKS < <(list_disks)
-  # Always offer "Other …" so a user can type a path the auto-detection missed
-  # (unusual controllers, /dev/mapper, etc.); it's the only choice when no
-  # eligible disks were found. gum choose has no non-selectable rows, so instead
-  # of a separate divider line (which would be focusable), the divider is fused
-  # into the "Other" label — it stands apart visually but isn't its own pickable
-  # item. The leading divider is only shown when there are disks to separate from.
-  OTHER_TEXT="Other (enter a disk path manually)"
-  if [[ ${#DISKS[@]} -gt 0 ]]; then
-    OTHER_LABEL="────────  $OTHER_TEXT"
-  else
-    OTHER_LABEL="$OTHER_TEXT"
-  fi
-  sel="$(printf '%s\n' "${DISKS[@]}" "$OTHER_LABEL" \
-    | gum choose --header "Install to which disk? (it WILL be wiped)")" \
-    || { echo "no disk selected" >&2; exit 1; }
-  [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
-  if [[ "$sel" == "$OTHER_LABEL" ]]; then
-    # Prefill with the main guessed disk (first detected) so the user can edit a
-    # near-correct path instead of typing from scratch; fall back to a hint when
-    # nothing was detected.
-    guessed_disk=""
-    [[ ${#DISKS[@]} -gt 0 ]] && guessed_disk="$(awk '{print $1}' <<<"${DISKS[0]}")"
-    DISK_ARG="$(gum input --prompt "Disk path: " \
-      --value "$guessed_disk" --placeholder "/dev/sda")" \
+  if [[ ${#DISKS[@]} -eq 0 ]]; then
+    # Nothing auto-detected: skip the picker and drop straight to manual entry.
+    echo "  disk detection found no eligible disks; enter a path manually" >&2
+    DISK_ARG="$(gum input --prompt "Disk path: " --placeholder "/dev/sda")" \
       || { echo "no disk entered" >&2; exit 1; }
   else
-    DISK_ARG=$(awk '{print $1}' <<<"$sel")
+    # Offer the detected disks plus an "Other …" escape hatch for paths the
+    # auto-detection missed (unusual controllers, /dev/mapper, etc.). gum choose
+    # has no non-selectable rows, so the divider is fused into the "Other" label
+    # (visually apart, but not its own pickable item) rather than a separate
+    # focusable divider line.
+    OTHER_LABEL="────────  Other (enter a disk path manually)"
+    sel="$(printf '%s\n' "${DISKS[@]}" "$OTHER_LABEL" \
+      | gum choose --header "Install to which disk? (it WILL be wiped)")" \
+      || { echo "no disk selected" >&2; exit 1; }
+    [[ -n "$sel" ]] || { echo "no disk selected" >&2; exit 1; }
+    if [[ "$sel" == "$OTHER_LABEL" ]]; then
+      # Prefill with the main guessed disk (first detected) so the user can edit
+      # a near-correct path instead of typing from scratch.
+      DISK_ARG="$(gum input --prompt "Disk path: " \
+        --value "$(awk '{print $1}' <<<"${DISKS[0]}")" --placeholder "/dev/sda")" \
+        || { echo "no disk entered" >&2; exit 1; }
+    else
+      DISK_ARG=$(awk '{print $1}' <<<"$sel")
+    fi
   fi
   # gum clears its widget after submit; echo the choice so it stays on screen.
   echo "  Install to disk: $DISK_ARG" >&2

--- a/nixos/_images/base/iso.nix
+++ b/nixos/_images/base/iso.nix
@@ -29,9 +29,13 @@
   boot.loader.systemd-boot.enable      = lib.mkForce false;
   boot.loader.efi.canTouchEfiVariables = lib.mkForce false;
 
-  # dmidecode: read SMBIOS/DMI (board model, BIOS, serial). install.sh's
-  # hardware-description auto-detection uses it, and it's handy for inspecting
-  # the target machine from the live ISO. Ship it in the base layer so every
-  # ISO flavour (installer + appliance) has it.
-  environment.systemPackages = [ pkgs.dmidecode ];
+  # Tools install.sh expects at runtime, shipped in the base layer so every ISO
+  # flavour (installer + appliance) has them:
+  #   - dmidecode: read SMBIOS/DMI (board model, BIOS, serial) for the
+  #     hardware-description auto-detection; also handy for inspecting the target
+  #     machine from the live ISO.
+  #   - gum: the interactive TUI (charmbracelet) install.sh drives for its
+  #     --interactive prompts. install.sh hard-requires it (no fallback), so it
+  #     must be present in the live environment.
+  environment.systemPackages = [ pkgs.dmidecode pkgs.gum ];
 }

--- a/nixos/_images/base/iso.nix
+++ b/nixos/_images/base/iso.nix
@@ -37,5 +37,7 @@
   #   - gum: the interactive TUI (charmbracelet) install.sh drives for its
   #     --interactive prompts. install.sh hard-requires it (no fallback), so it
   #     must be present in the live environment.
-  environment.systemPackages = [ pkgs.dmidecode pkgs.gum ];
+  #   - openssl: install.sh uses `openssl rand` to generate the random default
+  #     hostname suffix (coder-box-<random>); it's in the preflight tool checks.
+  environment.systemPackages = [ pkgs.dmidecode pkgs.gum pkgs.openssl ];
 }

--- a/nixos/_images/installer/iso.nix
+++ b/nixos/_images/installer/iso.nix
@@ -31,6 +31,11 @@ let
   # failure or --no-reboot.)
   installerLauncher = pkgs.writeShellScript "coder-box-installer-launch" ''
     cd /etc/nixos-repo 2>/dev/null || cd /
+    # The installer ISO is meant to be driven interactively from this console,
+    # so default to --interactive (gum prompts for everything not preset). Any
+    # extra args forwarded to the launcher are appended after it; --yes still
+    # wins (install.sh ignores --interactive when --yes is given).
+    set -- --interactive "$@"
     echo "=== Coder Box installer ==="
     echo "Running: sudo ./install.sh $*"
     echo


### PR DESCRIPTION
Closes #10.

Makes `install.sh` interactive (opt-in) and modernises its flag parsing.

## Changes

**getopt-based flag parsing**
- Parses options with GNU `getopt`, normalising `--flag=value`, bundled short flags, and option order into a canonical token stream.
- BSD/macOS `getopt` has no long-option support, so it's detected via its `--version` output and the installer exits with a clear error rather than mis-parsing. (This installer only runs on a NixOS live USB, which ships GNU getopt.)

**`--interactive` / `-i`**
- Prompts for any value **not already passed as a flag** (hostname, hardware desc, disk, admin email/password, NixOS user/password, LAN IP).
- Prompts only occur in interactive mode, and `--interactive` is **ignored when `--yes` is given**.
- Without `--disk` and without `--interactive`, the installer errors instead of forcing a picker.

**Interactive UI via `gum`**
- Prompts/selections/confirmations use [`gum`](https://github.com/charmbracelet/gum) (the modern alternative to ncurses dialog/whiptail): `gum input`, `gum choose`, `gum confirm`.
- `gum` is a hard requirement (checked in the preflight tool loop, no plain-`read` fallback) and is baked into the Coder box ISO via `nixos/_images/base/iso.nix`.

**Random default hostname**
- Default hostname now carries a random hex suffix (`coder-box-<random>`, e.g. `coder-box-deadbeef`) via `openssl rand -hex 4`, to avoid `*.local`/mDNS collisions when multiple boxes install with defaults. `openssl` added to the preflight checks.

## Validation
- `bash -n install.sh` passes.
- `nix eval .#nixosConfigurations._installer-iso.config.system.build.toplevel.drvPath` evaluates successfully, and `gum` is confirmed present in the installer ISO's `environment.systemPackages`.
