### PR TITLE
fix: make local.nix import conditional and fix incus-vm evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ hosts/*
 !hosts/_appliance_iso/
 !hosts/_installer-iso/
 !hosts/coder-thinkcentre/
+!hosts/incus-vm/
 !hosts/qemu-arm64/

--- a/agents.md
+++ b/agents.md
@@ -68,6 +68,13 @@ The `gh` CLI is installed as a helper for working with this repo (opening PRs,
 checking CI, etc.). It is not authenticated out of the box — run `gh auth login`
 once as the login user. Still don't push or open PRs unless explicitly asked.
 
+`.gitignore` ignores the whole `hosts/` directory (so users can drop their own
+hosts in without git noise), then un-ignores each centrally-managed host with a
+`!hosts/<host>/` line. **When you add a new centrally-managed host, add a
+matching `!hosts/<host>/` line to `.gitignore`** — otherwise its files stay
+ignored and `git add` rejects them (per-host `local.nix`/`facter.json` remain
+ignored via the `hosts/*/local.nix` rule).
+
 ## Template Management
 
 Templates live in two places:

--- a/hosts/incus-vm/default.nix
+++ b/hosts/incus-vm/default.nix
@@ -15,10 +15,20 @@
 {
   imports = [
     ./incus-vm.nix          # QEMU guest agents, networkd DHCP, no desktop stack
-    ./local.nix             # per-host secrets: admin creds, LAN IP, SSH keys
-    /etc/nixos/incus.nix    # hostname — written by incus-virtual-machine init
     # /etc/nixos/coder.nix  # only needed if this VM is also a coder-agent workspace
-  ];
+  ]
+  # local.nix (per-host secrets: admin creds, LAN IP, SSH keys) and
+  # /etc/nixos/incus.nix (hostname, written by incus-virtual-machine init) are
+  # imported only when present so the flake still evaluates on a fresh checkout
+  # where neither runtime file exists yet.
+  ++ lib.optional (builtins.pathExists ./local.nix) ./local.nix
+  ++ lib.optional (builtins.pathExists /etc/nixos/incus.nix) /etc/nixos/incus.nix;
+
+  # Default hostname so the flake evaluates even before /etc/nixos/incus.nix is
+  # written. When incus.nix is present it sets networking.hostName at normal
+  # priority, overriding this mkDefault. (The flake also injects the folder name
+  # "incus-vm" as a default, but this keeps the host self-contained.)
+  networking.hostName = lib.mkDefault "incus-vm";
 
   # Uncomment for aarch64 VMs (Apple Silicon, ARM servers, etc.).
   # The flake defaults to x86_64-linux; without this the build evaluates


### PR DESCRIPTION
## What

Make the `incus-vm` host's runtime imports conditional and add a default hostname so the flake evaluates cleanly on a fresh checkout.

## Why

`hosts/incus-vm/default.nix` was the only host importing its runtime files unconditionally:

- `./local.nix` — per-host secrets (gitignored, may not exist)
- `/etc/nixos/incus.nix` — hostname, written by `incus-virtual-machine` init at runtime (outside the flake tree)

Because both were hard imports, `nix eval`/`flake check` failed on any checkout where those files weren't present. Every other host (`coder-thinkcentre`, `qemu-arm64`, `_appliance-disk`, `_appliance_iso`, `_installer-iso`) already used the `lib.optional (builtins.pathExists ...)` pattern.

## Changes

- Import `./local.nix` and `/etc/nixos/incus.nix` via `lib.optional (builtins.pathExists ...)`, matching the existing repo pattern.
- Add `networking.hostName = lib.mkDefault "incus-vm"` so evaluation succeeds before the runtime hostname file exists. When `/etc/nixos/incus.nix` is present it sets the hostname with `mkForce`, which still overrides this default.

## Verification

With neither runtime file present:

- `nixosConfigurations.incus-vm.config.networking.hostName` → `"incus-vm"`
- `config.system.build.toplevel.drvPath` resolves with **no `--impure` needed**, confirming the flake evaluates on a clean checkout.