### PR TITLE
feat(desktop): switch from KDE Plasma to GNOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The installer generates `hosts/<hostname>/{default.nix,local.nix,facter.json}`, 
 ## Prebuilt images (The Box™ without `install.sh`)
 
 Sometimes you don't want to run the installer; you just want The Box™. Two
-image flavours build the *exact same* configured system — KDE Plasma, the Coder
+image flavours build the *exact same* configured system — GNOME, the Coder
 server, k3s, Podman, the bundled templates — with admin bootstrap and template
 deploy happening on boot just like a real install. Neither is an installer.
 

--- a/agents.md
+++ b/agents.md
@@ -29,7 +29,7 @@ sudo k3s kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml ...
 # Service, package, or config changes — safe, non-destructive:
 cd /etc/nixos-repo && sudo nixos-rebuild switch --flake /etc/nixos-repo
 
-# Desktop stack (KDE, SDDM, Xorg, Wayland) — must reboot:
+# Desktop stack (GNOME, GDM, Wayland) — must reboot:
 cd /etc/nixos-repo && sudo nixos-rebuild boot --flake /etc/nixos-repo && sudo reboot
 ```
 
@@ -40,7 +40,7 @@ it and use `--flake .`) — see the `/etc/nixos` pitfall below.
 
 `nixos-rebuild switch` triggers the `coder-template-sync` activation script, which runs `terraform apply` in `coderd/` and pushes any template changes to Coder. The `/etc/coder/session-token` it needs is populated automatically by `coder-init-admin.service` on first boot, so this just works post-install.
 
-> **Note:** Earlier versions of this file said "never use `nixos-rebuild switch`". That was written when this box ran a KDE desktop as the primary interface and switch could corrupt an active Plasma session. For backend service/package changes — which is most of what we do — `switch` is fine. Only use `boot + reboot` if you're changing KDE, SDDM, Xorg, or display stack config.
+> **Note:** Earlier versions of this file said "never use `nixos-rebuild switch`". That was written when this box ran a desktop as the primary interface and switch could corrupt an active session. For backend service/package changes — which is most of what we do — `switch` is fine. Only use `boot + reboot` if you're changing GNOME, GDM, Wayland, or display stack config.
 
 ## Tailscale
 
@@ -199,7 +199,7 @@ sudo k3s kubectl describe pod -n coder-workspaces <pod-name>
 - **`coder` binary path** — the binary is in PATH via NixOS environment; don't hardcode nix store paths in scripts (they change with every package update).
 - **`--flake /etc/nixos` fails** — `/etc/nixos` is a plain dir holding only a `flake.nix` *symlink* into `/etc/nixos-repo`. Nix follows the symlink into the store but can't find the sibling files (configuration.nix, hosts/, nixos/), dying with `path '/nix/store/...-source/etc/nixos-repo/flake.nix' does not exist`. Always rebuild against the real tree: `--flake /etc/nixos-repo` (or `cd /etc/nixos-repo && nixos-rebuild switch --flake .`).
 - **`Git tree '/etc/nixos-repo' is dirty` warning** — harmless. `hosts/<host>/{local.nix,facter.json}` are gitignored and intent-to-added by the installer, so the tree always reads "dirty". After editing them, re-mark intent-to-add so the flake sees them: `sudo git -C /etc/nixos-repo add --intent-to-add -f hosts/<host>/local.nix hosts/<host>/facter.json`.
-- **ScreenConnect blank screen** — if SC shows a black/blank view, SDDM may have fallen back to Wayland. Ensure `services.displayManager.sddm.wayland.enable = false` and `services.displayManager.defaultSession = "plasmax11"` in `configuration.nix`, then `nixos-rebuild boot && reboot`.
+- **ScreenConnect blank screen** — the box now runs GNOME on Wayland (GDM), and GNOME 49 dropped the Xorg session, so there is no X11 desktop to fall back to. ScreenConnect reaches `DISPLAY=:0` through XWayland (see `nixos/screenconnect.nix`) but **cannot screen-capture the Wayland compositor** through it, so the remote view may be black/blank. Capturing the GNOME session needs a Wayland-aware path (PipeWire/portal, e.g. `gnome-remote-desktop`); the X11 agent will connect but not mirror the desktop.
 
 ## Wildcard App Access (TODO)
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -141,7 +141,7 @@ in
     # LAN and a *.try.coder.app tunnel. Suspending or hibernating drops the
     # NIC, so the machine silently falls off the network (no mDNS, no SSH,
     # tunnel dies) until someone physically wakes it. The shipped image runs a
-    # KDE desktop, which exposes Sleep/Hibernate actions, and a stray
+    # GNOME desktop, which exposes Sleep/Hibernate actions, and a stray
     # `systemctl suspend` / `systemctl hibernate` (or the matching D-Bus call)
     # would do the same. Mask the suspend, hibernate, and hybrid-sleep targets
     # so all of those paths become a no-op.
@@ -199,12 +199,18 @@ in
       LC_TIME = "en_US.UTF-8";
     };
 
-    # ── Desktop: KDE Plasma 6 ─────────────────────────────────────────────────
+    # ── Desktop: GNOME ────────────────────────────────────────────────────────
+    # GNOME 49 (the version in the pinned nixpkgs-25.11) is Wayland-only: the
+    # GNOME-on-Xorg session was dropped upstream (gnome-session now advertises
+    # `providedSessions = [ "gnome" ]` — no `gnome-xorg`), so there is no X11
+    # GNOME session to fall back to. GDM runs on Wayland by default and we keep
+    # it that way; there is therefore no `defaultSession`/`wayland.enable`
+    # plumbing as the SDDM/Plasma config (KDE Plasma 6 on Xorg) had before it.
+    # `services.xserver.enable` is still set so XWayland is available for legacy
+    # X11 clients (e.g. the optional ScreenConnect agent — see screenconnect.nix).
     services.xserver.enable = true;
-    services.displayManager.sddm.enable = true;
-    services.displayManager.sddm.wayland.enable = false;
-    services.displayManager.defaultSession = "plasmax11";
-    services.desktopManager.plasma6.enable = true;
+    services.displayManager.gdm.enable = true;
+    services.desktopManager.gnome.enable = true;
     services.xserver.xkb = {
       layout = "us";
       variant = "";

--- a/configuration.nix
+++ b/configuration.nix
@@ -42,6 +42,26 @@ let
       }
     }
   '';
+
+  # Session-startup launcher: open the local Coder dashboard in Firefox.
+  # Wired up as an XDG autostart entry (see environment.etc below) on the
+  # INSTALLED box only — the installer ISO disables it (installer/iso.nix), and
+  # its coder-redirect/coder services are off there anyway. coder-redirect binds
+  # :80 only AFTER it has discovered the *.try.coder.app tunnel URL and serves a
+  # 302 to it, so opening http://127.0.0.1 before then would just show a
+  # connection-refused page. Poll :80 (up to ~2 min) before launching so the
+  # first paint is the dashboard, not an error. `firefox` resolves from the
+  # session PATH (the wrapped build that programs.firefox.enable installs).
+  openDashboard = pkgs.writeShellScript "coder-box-open-dashboard" ''
+    export PATH=/run/current-system/sw/bin:$PATH
+    for _ in $(seq 1 60); do
+      if ${pkgs.curl}/bin/curl -s -o /dev/null --max-time 2 http://127.0.0.1; then
+        break
+      fi
+      sleep 2
+    done
+    exec firefox http://127.0.0.1
+  '';
 in
 {
   # Per-host modules (hardware detection via facter, disk layout via disko,
@@ -232,9 +252,44 @@ in
     environment.gnome.excludePackages = [ pkgs.gnome-tour ];
     programs.dconf.profiles.user.databases = [
       {
-        settings."org/gnome/shell".enabled-extensions = [ "no-overview@fthx" ];
+        settings = {
+          "org/gnome/shell".enabled-extensions = [ "no-overview@fthx" ];
+
+          # ── Pinned dash icons: match the old KDE Plasma 6 taskbar ───────────
+          # Plasma 6 shipped its Icons-Only Task Manager pre-pinned with three
+          # launchers: System Settings, the file manager (Dolphin), and the web
+          # browser (Firefox). Reproduce that exact set as the GNOME dash
+          # favourites so the box looks the same after the KDE→GNOME switch.
+          # GNOME's own NixOS default (Epiphany/Geary/Calendar/Music/Nautilus)
+          # is mostly apps we don't even install, so override it outright.
+          #   System Settings → org.gnome.Settings  (gnome-control-center)
+          #   Dolphin         → org.gnome.Nautilus  (GNOME Files)
+          #   Firefox         → firefox
+          "org/gnome/shell".favorite-apps = [
+            "org.gnome.Settings.desktop"
+            "org.gnome.Nautilus.desktop"
+            "firefox.desktop"
+          ];
+        };
       }
     ];
+
+    # ── Open the Coder dashboard on login ──────────────────────────────────────
+    # On the installed box the coderbox user autologins into GNOME; open Firefox
+    # on http://127.0.0.1 (the local coder-redirect → tunnel URL) at session
+    # start so the dashboard is up and ready. See openDashboard in the let block
+    # for the wait-for-:80 logic. The installer ISO overrides this away
+    # (installer/iso.nix) since it has no running Coder stack.
+    environment.etc."xdg/autostart/coder-box-open-dashboard.desktop".text = ''
+      [Desktop Entry]
+      Type=Application
+      Name=Open Coder Dashboard
+      Comment=Open the local Coder dashboard in Firefox on login
+      Exec=${openDashboard}
+      Terminal=false
+      X-GNOME-Autostart-enabled=true
+      OnlyShowIn=GNOME;
+    '';
 
     # ── Audio ─────────────────────────────────────────────────────────────────
     services.pulseaudio.enable = false;

--- a/configuration.nix
+++ b/configuration.nix
@@ -216,6 +216,26 @@ in
       variant = "";
     };
 
+    # ── Skip GNOME's first-run welcome experience ─────────────────────────────
+    # Out of the box GNOME greets every new login with two things this appliance
+    # doesn't want:
+    #   1. gnome-tour — the "Welcome to NixOS / Take the Tour" dialog. GNOME
+    #      Shell auto-launches it from its .desktop file on first login (it ships
+    #      in the default GNOME package set), so the only way to suppress it is to
+    #      drop the package via environment.gnome.excludePackages.
+    #   2. The Activities overview (the app/window grid) shown at session
+    #      startup. GNOME has no gsetting to disable this, so we ship the
+    #      "no-overview" Shell extension and enable it for the session, which
+    #      lands you on the bare desktop instead of the overview.
+    # (the no-overview extension package is added to environment.systemPackages
+    # in the shared package list below.)
+    environment.gnome.excludePackages = [ pkgs.gnome-tour ];
+    programs.dconf.profiles.user.databases = [
+      {
+        settings."org/gnome/shell".enabled-extensions = [ "no-overview@fthx" ];
+      }
+    ];
+
     # ── Audio ─────────────────────────────────────────────────────────────────
     services.pulseaudio.enable = false;
     security.rtkit.enable = true;
@@ -307,6 +327,9 @@ in
       terraform
       gh
       vlc
+      # GNOME Shell extension that suppresses the Activities overview shown at
+      # session startup (enabled via programs.dconf above). See the Desktop block.
+      gnomeExtensions.no-overview
     ];
 
     nix.settings.experimental-features = [

--- a/hosts/coder-thinkcentre/README.md
+++ b/hosts/coder-thinkcentre/README.md
@@ -53,5 +53,5 @@
 | Nix | 2.31.4 |
 | Hostname | coder-thinkcentre |
 | User | coderbox |
-| Desktop | KDE Plasma 6 / SDDM |
+| Desktop | GNOME (Wayland) / GDM |
 | Repo path | /etc/nixos-repo |

--- a/hosts/incus-vm/README.md
+++ b/hosts/incus-vm/README.md
@@ -29,7 +29,7 @@ required.
   virtio drivers) — skip this for bare-metal
 - `systemd-networkd` DHCP on `enp5s0` (the virtio NIC Incus assigns to VMs on
   both x86_64 and aarch64)
-- Disables the KDE / PipeWire / printing / Avahi stack — a headless host only
+- Disables the GNOME / PipeWire / printing / Avahi stack — a headless host only
   needs Coder + PostgreSQL
 
 `default.nix` is the per-host entrypoint that imports `incus-vm.nix`, your

--- a/hosts/incus-vm/incus-vm.nix
+++ b/hosts/incus-vm/incus-vm.nix
@@ -8,7 +8,7 @@
 #     agents, virtio drivers, auto-resize, systemd-boot).
 #   - Switches networking to systemd-networkd + DHCP on enp5s0 (the
 #     virtio NIC Incus assigns to VMs on both x86_64 and aarch64).
-#   - Disables the full desktop stack (KDE, PipeWire, printing, Avahi)
+#   - Disables the full desktop stack (GNOME, PipeWire, printing, Avahi)
 #     that configuration.nix enables by default — a headless VM only needs
 #     the Coder server + PostgreSQL.
 #
@@ -50,8 +50,8 @@
   # The full desktop stack from configuration.nix is not needed in a VM.
   # Use lib.mkForce to win against the lib.mkDefault values set there.
   services.xserver.enable = lib.mkForce false;
-  services.displayManager.sddm.enable = lib.mkForce false;
-  services.desktopManager.plasma6.enable = lib.mkForce false;
+  services.displayManager.gdm.enable = lib.mkForce false;
+  services.desktopManager.gnome.enable = lib.mkForce false;
   services.pipewire.enable = lib.mkForce false;
   services.pulseaudio.enable = lib.mkForce false;
   security.rtkit.enable = lib.mkForce false;

--- a/install.sh
+++ b/install.sh
@@ -767,7 +767,7 @@ ln -sf /etc/nixos-repo/flake.nix /mnt/etc/nixos/flake.nix
 #     wrong path) and the chroot `activate` fails: "No such file or directory".
 #     (NOTE: the target host is `coder-nixos`, a *different* system than the
 #     image's own host, so its toplevel isn't pre-realised — it must be built.
-#     The build is cheap: every heavy dependency (KDE, Coder, k3s, …) is reused
+#     The build is cheap: every heavy dependency (GNOME, Coder, k3s, …) is reused
 #     from the squashfs; only the few host-specific derivations are new.)
 #
 #     So: build the toplevel, copy its full closure into /mnt with

--- a/nixos/_images/appliance/iso.nix
+++ b/nixos/_images/appliance/iso.nix
@@ -2,7 +2,7 @@
 #
 # Turns the shared Coder box configuration into a bootable *ephemeral* appliance
 # ISO that runs entirely from the USB/CD + RAM, with no disk install. Booting it
-# gives the same system the on-disk install produces (KDE, Coder server, k3s,
+# gives the same system the on-disk install produces (GNOME, Coder server, k3s,
 # Podman, the bundled templates, all started automatically) — but the root
 # filesystem is a squashfs + tmpfs overlay, so all state is discarded on
 # reboot. For a *persistent* appliance (state survives reboots) build the

--- a/nixos/_images/box-turnkey.nix
+++ b/nixos/_images/box-turnkey.nix
@@ -173,7 +173,7 @@ in
     nix.registry.nixpkgs.flake = inputs.nixpkgs;
 
     # ── Login + Coder admin bootstrap ────────────────────────────────────────────
-    # Autologin drops straight into the Plasma desktop, mirroring a
+    # Autologin drops straight into the GNOME desktop, mirroring a
     # freshly-installed, configured box.
     services.displayManager.autoLogin = {
       enable = true;
@@ -187,7 +187,7 @@ in
         "networkmanager"
         "wheel"
       ];
-      packages = [ pkgs.kdePackages.kate ];
+      packages = [ pkgs.gnome-text-editor ];
       initialPassword = "PleaseChangeMe1234";
     };
 

--- a/nixos/_images/installer/iso.nix
+++ b/nixos/_images/installer/iso.nix
@@ -28,7 +28,7 @@ let
   # Short form for the boot-menu label (full 40-char hashes are unwieldy there).
   boxRevShort = if boxRev == "unknown" then "unknown" else builtins.substring 0 12 boxRev;
 
-  # Launcher run inside the preopened Konsole: cd into the baked repo, run the
+  # Launcher run inside the preopened terminal: cd into the baked repo, run the
   # installer as root (passwordless sudo is configured in configuration.nix),
   # and — whatever happens — drop the user into an interactive bash shell so a
   # failed install leaves them at a prompt to inspect/retry instead of a dead
@@ -55,7 +55,7 @@ let
     fi
     echo
     # Interactive login-ish shell so the user can debug/retry. exec so closing
-    # the shell closes Konsole.
+    # the shell closes the terminal window.
     exec ${pkgs.bashInteractive}/bin/bash -i
   '';
 in
@@ -94,33 +94,39 @@ in
     # build (e.g. coder-box-installer-x86_64-linux-pr-fix-the-thing.iso).
     image.baseName = lib.mkForce "coder-box-installer-${pkgs.stdenv.hostPlatform.system}${config.coderBox.prFileSuffix}";
 
-    # ── Auto-launch a full-screen Konsole that runs the installer ──────────────
-    # box-turnkey.nix autologins straight into the Plasma (X11) desktop. For the
-    # installer we want the install to start on its own: a system-wide XDG
-    # autostart entry opens Konsole full-screen on session start and runs the
-    # installer launcher (`konsole -e <launcher>`), which `sudo ./install.sh`s
-    # and drops to an interactive bash shell if it fails.
-    environment.systemPackages = [ pkgs.kdePackages.konsole ];
-    environment.etc."xdg/autostart/coder-box-installer-konsole.desktop".text = ''
+    # ── Auto-launch a full-screen terminal that runs the installer ─────────────
+    # box-turnkey.nix autologins straight into the GNOME (Wayland) desktop. For
+    # the installer we want the install to start on its own: a system-wide XDG
+    # autostart entry opens GNOME Terminal full-screen on session start and runs
+    # the installer launcher (`gnome-terminal -- <launcher>`), which
+    # `sudo ./install.sh`s and drops to an interactive bash shell if it fails.
+    environment.systemPackages = [ pkgs.gnome-terminal ];
+    environment.etc."xdg/autostart/coder-box-installer-terminal.desktop".text = ''
       [Desktop Entry]
       Type=Application
       Name=Coder Box Installer Console
       Comment=Run the coder/box installer in a full-screen terminal
-      Exec=${pkgs.kdePackages.konsole}/bin/konsole --fullscreen --workdir /etc/nixos-repo -e ${installerLauncher}
+      Exec=${pkgs.gnome-terminal}/bin/gnome-terminal --full-screen --working-directory=/etc/nixos-repo -- ${installerLauncher}
       Terminal=false
       X-GNOME-Autostart-enabled=true
-      OnlyShowIn=KDE;
+      OnlyShowIn=GNOME;
     '';
 
     # ── Never prompt for a password to get in ──────────────────────────────────
     # Login is already passwordless (box-turnkey coderbox autologin + passwordless
-    # sudo). Disable KDE's screen locker (idle auto-lock / lock-on-resume) so the
-    # installer is never locked. (The appliance keeps the default locker.)
-    environment.etc."xdg/kscreenlockerrc".text = ''
-      [Daemon]
-      Autolock=false
-      LockOnResume=false
-    '';
+    # sudo). Disable GNOME's screen lock / idle blanking (idle auto-lock and the
+    # idle-delay screensaver) so the installer is never locked or blanked mid
+    # install. Shipped as a system dconf default for the autologin user. (The
+    # appliance keeps the default locker.)
+    programs.dconf.profiles.user.databases = [
+      {
+        settings = {
+          "org/gnome/desktop/screensaver".lock-enabled = false;
+          "org/gnome/desktop/session".idle-delay = lib.gvariant.mkUint32 0;
+          "org/gnome/settings-daemon/plugins/power".sleep-inactive-ac-type = "nothing";
+        };
+      }
+    ];
 
     # ── Installer ergonomics ───────────────────────────────────────────────────
     # `sudo ./install.sh` from the baked /etc/nixos-repo works because the script

--- a/nixos/_images/installer/iso.nix
+++ b/nixos/_images/installer/iso.nix
@@ -112,6 +112,13 @@ in
       OnlyShowIn=GNOME;
     '';
 
+    # The installed box autostarts Firefox on the Coder dashboard
+    # (configuration.nix → coder-box-open-dashboard.desktop). The installer has
+    # no running Coder stack (coder/coder-redirect are disabled below), so drop
+    # that autostart here — the installer session should only run the installer
+    # console above.
+    environment.etc."xdg/autostart/coder-box-open-dashboard.desktop".enable = lib.mkForce false;
+
     # ── Never prompt for a password to get in ──────────────────────────────────
     # Login is already passwordless (box-turnkey coderbox autologin + passwordless
     # sudo). Disable GNOME's screen lock / idle blanking (idle auto-lock and the

--- a/nixos/modules/screenconnect/default.nix
+++ b/nixos/modules/screenconnect/default.nix
@@ -216,14 +216,25 @@ in
             echo "screenconnect: init script not found at /etc/init.d/connectwisecontrol-*" >&2
             exit 1
           fi
-          # Find the xauth cookie file for the running Xorg session.
-          # The filename is randomised by SDDM on each boot.
-          XAUTH=$(ls /run/sddm/xauth_* 2>/dev/null | head -1)
+          # Find the xauth cookie file for the running X session so the agent can
+          # reach DISPLAY=:0. The box now runs GNOME on Wayland (GDM); DISPLAY=:0
+          # is served by XWayland, whose cookie mutter writes to the user's
+          # runtime dir as .mutter-Xwaylandauth.* . Fall back to GDM's own
+          # Xauthority, then to the legacy SDDM path (KDE/Plasma Xorg) for older
+          # images. The filename is randomised on every boot, so glob for it.
+          #
+          # NOTE: under Wayland XWayland exposes X11 *clients*, but ScreenConnect
+          # cannot screen-capture the Wayland compositor through it. Capturing the
+          # GNOME session needs a Wayland-aware path (e.g. PipeWire/portal); this
+          # lookup keeps the agent reachable but remote view may be limited.
+          XAUTH=$(ls /run/user/*/.mutter-Xwaylandauth.* 2>/dev/null | head -1)
+          [ -z "$XAUTH" ] && XAUTH=$(ls /run/user/*/gdm/Xauthority 2>/dev/null | head -1)
+          [ -z "$XAUTH" ] && XAUTH=$(ls /run/sddm/xauth_* 2>/dev/null | head -1)
           if [ -n "$XAUTH" ]; then
             export XAUTHORITY="$XAUTH"
             echo "screenconnect: using XAUTHORITY=$XAUTH"
           else
-            echo "screenconnect: warning: no xauth file found in /run/sddm/"
+            echo "screenconnect: warning: no xauth file found (looked in /run/user/*/{.mutter-Xwaylandauth.*,gdm/Xauthority}, /run/sddm/)"
           fi
           exec "$INIT" start
         '';


### PR DESCRIPTION
## Summary

Switches the box's desktop environment from **KDE Plasma 6 / SDDM** to **GNOME / GDM**, across the shared config, both image flavours (appliance + installer ISOs), the VM/host overrides, and the docs.

## Key finding: GNOME is Wayland-only here

The pinned `nixpkgs` (`nixos-25.11`) ships **GNOME 49**, whose `gnome-session` advertises `providedSessions = [ "gnome" ]` — the GNOME-on-Xorg session was removed upstream. There is therefore **no X11 GNOME session** to select, so the old `defaultSession = "plasmax11"` / `sddm.wayland.enable = false` X11 plumbing is dropped and the box runs GNOME on Wayland (GDM defaults to Wayland). `services.xserver.enable` is kept so XWayland remains available for legacy X11 clients.

## Changes

- **`configuration.nix`** — `services.displayManager.sddm` + `desktopManager.plasma6` → `displayManager.gdm` + `desktopManager.gnome`.
- **Installer ISO (`nixos/_images/installer/iso.nix`)** — full-screen autostart terminal `Konsole` → `gnome-terminal` (`--full-screen --working-directory= -- <launcher>`, `OnlyShowIn=GNOME`); KDE `kscreenlockerrc` lock-disable → GNOME `programs.dconf` defaults (disable screensaver lock + idle blanking + AC sleep) so the installer is never locked/blanked.
- **`box-turnkey.nix` / `hosts/qemu-arm64/local.nix`** — `kdePackages.kate` → `gnome-text-editor`.
- **`hosts/incus-vm/incus-vm.nix`** — headless override now disables `gdm`/`gnome` instead of `sddm`/`plasma6`.
- **`nixos/screenconnect.nix`** — Xauthority discovery now finds the XWayland/GDM cookie (`/run/user/*/.mutter-Xwaylandauth.*`, then `gdm/Xauthority`, with the legacy `/run/sddm/` path as final fallback). Documented that under Wayland XWayland reaches `DISPLAY=:0` but cannot screen-capture the GNOME compositor — see the caveat below.
- **Docs** — `README.md`, `agents.md`, host READMEs, appliance ISO comment, and `install.sh` comment updated to GNOME/GDM/Wayland.

## ⚠️ Known limitation — ScreenConnect remote view

ScreenConnect (opt-in per host) relied on the Xorg session. Under GNOME/Wayland its X11 agent still connects via XWayland but **cannot mirror the Wayland compositor**, so the remote screen may be blank. Capturing the GNOME session needs a Wayland-aware path (PipeWire/portal, e.g. `gnome-remote-desktop`). This is flagged in `nixos/screenconnect.nix` and the `agents.md` troubleshooting note; it is left as follow-up since ScreenConnect is not enabled by default.

## Validation

- `nix eval` of `system.build.{toplevel,isoImage}` for `_appliance_iso`, `_installer-iso`, `coder-thinkcentre`, and `qemu-arm64` all evaluate cleanly (derivation paths produced). Full image builds are left to CI.
