### PR TITLE
ci: install Nix on the host + cache /nix/store (drop docker run)

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -36,17 +36,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Build parallelism + substituter tuning. max-jobs runs independent
-          # derivations concurrently and cores=0 lets each build use all CPUs;
-          # bumping http-connections / max-substitution-jobs widens the binary
-          # cache fetch pipeline so restoring the tool closure isn't bottlenecked
-          # on the default 25 connections / 16 parallel substitutions.
-          extra-conf: |
-            max-jobs = auto
-            cores = 0
-            http-connections = 128
-            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
@@ -71,17 +60,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Build parallelism + substituter tuning. max-jobs runs independent
-          # derivations concurrently and cores=0 lets each build use all CPUs;
-          # bumping http-connections / max-substitution-jobs widens the binary
-          # cache fetch pipeline so restoring the tool closure isn't bottlenecked
-          # on the default 25 connections / 16 parallel substitutions.
-          extra-conf: |
-            max-jobs = auto
-            cores = 0
-            http-connections = 128
-            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,10 +8,10 @@
 # Splitting them means a formatting miss and a lint finding show up as distinct,
 # independently-rerunnable checks.
 #
-# Unlike the heavy image builds (test.yml / release.yml, which run inside the
-# nixos/nix container), these checks are light, so we just install Nix on the
-# runner with nix-installer-action (flakes enabled) and run `make` directly —
-# GNU Make is preinstalled on the GitHub Ubuntu runners.
+# Like the image builds (test.yml / release.yml), Nix is installed on the runner
+# with nix-installer-action (flakes enabled) and the /nix/store is cached across
+# runs (nix-community/cache-nix-action). `make` runs directly — GNU Make is
+# preinstalled on the GitHub Ubuntu runners.
 
 name: Code quality
 
@@ -37,6 +37,15 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
 
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # Formatting/linting tools (treefmt, statix, …) come from the flake;
+          # key on the lockfile + Nix sources so the tool closure is reused.
+          primary-key: nix-fmt-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-fmt-${{ runner.os }}-${{ runner.arch }}-
+          gc-max-store-size-linux: 2G
+
       # Check-only (`--ci`): fails with a diff if anything is unformatted. Does
       # NOT modify the tree — run `make fmt` locally to fix.
       - name: make fmt/check
@@ -51,6 +60,15 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # Same tool closure as the format job; key on the lockfile + Nix
+          # sources so it is reused across runs.
+          primary-key: nix-fmt-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-fmt-${{ runner.os }}-${{ runner.arch }}-
+          gc-max-store-size-linux: 2G
 
       # Check-only (`--ci`): fails with a diff (statix/deadnix) or findings
       # (shellcheck). Does NOT modify the tree.

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -36,6 +36,17 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Build parallelism + substituter tuning. max-jobs runs independent
+          # derivations concurrently and cores=0 lets each build use all CPUs;
+          # bumping http-connections / max-substitution-jobs widens the binary
+          # cache fetch pipeline so restoring the tool closure isn't bottlenecked
+          # on the default 25 connections / 16 parallel substitutions.
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 128
+            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
@@ -60,6 +71,17 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Build parallelism + substituter tuning. max-jobs runs independent
+          # derivations concurrently and cores=0 lets each build use all CPUs;
+          # bumping http-connections / max-substitution-jobs widens the binary
+          # cache fetch pipeline so restoring the tool closure isn't bottlenecked
+          # on the default 25 connections / 16 parallel substitutions.
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 128
+            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,17 +74,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Build parallelism + substituter tuning. max-jobs runs independent
-          # derivations concurrently and cores=0 lets each build use all CPUs;
-          # bumping http-connections / max-substitution-jobs widens the binary
-          # cache fetch pipeline so restoring the closure isn't bottlenecked on
-          # the default 25 connections / 16 parallel substitutions.
-          extra-conf: |
-            max-jobs = auto
-            cores = 0
-            http-connections = 128
-            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,9 @@
 #     and optionally a ref/commit to build.
 #
 # Like test.yml, each arch builds on its own native runner with Nix installed
-# directly on the host (cachix/install-nix-action) and the /nix/store cached
-# across runs (nix-community/cache-nix-action). Bare `make <target>` resolves to
+# directly on the host (DeterminateSystems/nix-installer-action) and the
+# /nix/store cached across runs (nix-community/cache-nix-action). Bare
+# `make <target>` resolves to
 # the runner's native currentSystem; the resulting ISO + its .sha256 sidecar are
 # dereferenced into a host mktemp dir. The release job gathers all ISOs and
 # attaches them (with sha256 checksums) to the release.
@@ -72,10 +73,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,12 @@
 #   * run manually from the Actions tab (workflow_dispatch), supplying a tag
 #     and optionally a ref/commit to build.
 #
-# Like test.yml, each arch builds natively and the build runs inside the
-# `nixos/nix` container via `docker run` (the whole job can't use `container:`
-# because that image lacks a glibc loader for GitHub's bundled Node, which
-# breaks every JS action). Bare `make <target>` resolves to the runner's native
-# currentSystem; the resulting ISO is copied out of the ephemeral container
-# store into a host mktemp dir. The release job gathers all ISOs and attaches
-# them (with sha256 checksums) to the release.
+# Like test.yml, each arch builds on its own native runner with Nix installed
+# directly on the host (cachix/install-nix-action) and the /nix/store cached
+# across runs (nix-community/cache-nix-action). Bare `make <target>` resolves to
+# the runner's native currentSystem; the resulting ISO + its .sha256 sidecar are
+# dereferenced into a host mktemp dir. The release job gathers all ISOs and
+# attaches them (with sha256 checksums) to the release.
 
 name: Build and release ISO
 
@@ -72,36 +71,36 @@ jobs:
           # to release an arbitrary commit.
           ref: ${{ github.event.inputs.ref }}
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # ISO closures are large; cap the saved store so a build can't blow
+          # past the repo's GitHub Actions cache budget (10G total).
+          primary-key: nix-images-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-images-${{ runner.os }}-${{ runner.arch }}-
+          gc-max-store-size-linux: 8G
+
       - name: Build ISO
         id: build
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          # Host /dist volume, bind-mounted into the container, where the build
-          # drops the finished ISO (the container's /nix/store is ephemeral, so
-          # the in-tree out/ symlink would dangle on the host — we dereference
-          # the built ISO into /dist instead).
+          # Nix is on the host, so make/git (preinstalled on the runner) build
+          # straight into the host /nix/store. The ISO target puts the image and
+          # its .sha256 sidecar together in out/<target>-iso/iso, so a single
+          # cp -L dereferences both into a real mktemp dir for upload (release
+          # consumers can verify the download). Bare target → native
+          # currentSystem (matrix pins the matching native runner).
           dist="$(mktemp -d)"
           echo "dist=$dist" >>"$GITHUB_OUTPUT"
-          outlink="out/$TARGET-iso/iso"
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            -v "$dist":/dist \
-            -e TARGET -e outlink="$outlink" \
-            nixos/nix:latest \
-            sh -euc '
-              export NIX_CONFIG="experimental-features = nix-command flakes"
-              git config --global --add safe.directory /work
-              # gnumake provides "make"; git lets the Makefile stamp the rev. The
-              # ISO targets put the image and its .sha256 sidecar together in
-              # out/<target>-iso/iso, so a single cp -L grabs both (release
-              # consumers can verify the download). Bare target → native
-              # currentSystem (matrix pins the matching native runner).
-              nix-shell -p gnumake git --run "make $TARGET/iso"
-              # Dereference the build store symlink (+ checksum sidecar) into
-              # the /dist volume.
-              cp -L "$outlink"/* /dist/
-            '
+          make "$TARGET/iso"
+          cp -L "out/$TARGET-iso/iso"/* "$dist/"
           ls -lh "$dist"
 
       - name: Upload ISO artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,17 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Build parallelism + substituter tuning. max-jobs runs independent
+          # derivations concurrently and cores=0 lets each build use all CPUs;
+          # bumping http-connections / max-substitution-jobs widens the binary
+          # cache fetch pipeline so restoring the closure isn't bottlenecked on
+          # the default 25 connections / 16 parallel substitutions.
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 128
+            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,14 @@
 # bad references / type errors surface fast; the matrix build jobs then realise
 # (or, drv-only, just instantiate) the images.
 #
-# Nix is installed natively on each runner (cachix/install-nix-action) rather
-# than run from the `nixos/nix` container — that container lacks a standard
-# glibc loader, so GitHub's bundled Node couldn't run there and JS actions
-# failed; installing on the host avoids that entirely and, crucially, lets us
-# cache the /nix/store across runs (nix-community/cache-nix-action, backed by
-# the GitHub Actions cache). Each arch builds on its own native runner, so
-# `make <kind>/iso` resolves to the runner's native `builtins.currentSystem`.
+# Nix is installed natively on each runner (DeterminateSystems/nix-installer-
+# action) rather than run from the `nixos/nix` container — that container lacks
+# a standard glibc loader, so GitHub's bundled Node couldn't run there and JS
+# actions failed; installing on the host avoids that entirely and, crucially,
+# lets us cache the /nix/store across runs (nix-community/cache-nix-action,
+# backed by the GitHub Actions cache). Each arch builds on its own native
+# runner, so `make <kind>/iso` resolves to the runner's native
+# `builtins.currentSystem`.
 #
 # Triggers / what gets built per kind:
 #   * push to main                     → drv-only: just instantiate each kind's
@@ -71,10 +72,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
@@ -167,10 +165,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,8 @@ jobs:
           restore-prefixes-first-match: nix-flake-${{ runner.os }}-${{ runner.arch }}-
           gc-max-store-size-linux: 5G
 
-      - name: nix flake check
-        run: nix flake check --impure --no-build --all-systems
+      - name: Flake check
+        run: make check
 
   # Tiny pre-job that decides, per kind, whether to build the full ISO or just
   # instantiate the derivation, and assembles a short human title for the build
@@ -221,22 +221,20 @@ jobs:
           build_kind appliance "$APPLIANCE_FULL"
           ls -lh "$dist"
 
+      # One artifact per kind, each bundling that kind's ISO with its .sha256
+      # sidecar (a single upload-artifact step uploads its matched files
+      # CONCURRENTLY, so the multi-GB ISO and its checksum go up together).
+      # Installer and appliance stay in SEPARATE artifacts so each kind can be
+      # downloaded on its own. Each step runs only when its kind built full.
       - name: Upload installer ISO artifact
         if: env.INSTALLER_FULL == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: coder-box-installer-${{ matrix.system }}
-          path: ${{ steps.build.outputs.dist }}/coder-box-installer-*.iso
+          path: |
+            ${{ steps.build.outputs.dist }}/coder-box-installer-*.iso
+            ${{ steps.build.outputs.dist }}/coder-box-installer-*.iso.sha256
           # Verification build; keep storage cost minimal.
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload installer checksum artifact
-        if: env.INSTALLER_FULL == 'true'
-        uses: actions/upload-artifact@v5
-        with:
-          name: coder-box-installer-${{ matrix.system }}-sha256
-          path: ${{ steps.build.outputs.dist }}/coder-box-installer-*.iso.sha256
           retention-days: 1
           if-no-files-found: error
 
@@ -245,15 +243,8 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           name: coder-box-appliance-${{ matrix.system }}
-          path: ${{ steps.build.outputs.dist }}/coder-box-appliance-*.iso
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload appliance checksum artifact
-        if: env.APPLIANCE_FULL == 'true'
-        uses: actions/upload-artifact@v5
-        with:
-          name: coder-box-appliance-${{ matrix.system }}-sha256
-          path: ${{ steps.build.outputs.dist }}/coder-box-appliance-*.iso.sha256
+          path: |
+            ${{ steps.build.outputs.dist }}/coder-box-appliance-*.iso
+            ${{ steps.build.outputs.dist }}/coder-box-appliance-*.iso.sha256
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,17 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Build parallelism + substituter tuning. max-jobs runs independent
+          # derivations concurrently and cores=0 lets each build use all CPUs;
+          # bumping http-connections / max-substitution-jobs widens the binary
+          # cache fetch pipeline so restoring the closure isn't bottlenecked on
+          # the default 25 connections / 16 parallel substitutions.
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 128
+            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
@@ -166,6 +177,17 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
+        with:
+          # Build parallelism + substituter tuning. max-jobs runs independent
+          # derivations concurrently and cores=0 lets each build use all CPUs;
+          # bumping http-connections / max-substitution-jobs widens the binary
+          # cache fetch pipeline so restoring the closure isn't bottlenecked on
+          # the default 25 connections / 16 parallel substitutions.
+          extra-conf: |
+            max-jobs = auto
+            cores = 0
+            http-connections = 128
+            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,17 +73,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Build parallelism + substituter tuning. max-jobs runs independent
-          # derivations concurrently and cores=0 lets each build use all CPUs;
-          # bumping http-connections / max-substitution-jobs widens the binary
-          # cache fetch pipeline so restoring the closure isn't bottlenecked on
-          # the default 25 connections / 16 parallel substitutions.
-          extra-conf: |
-            max-jobs = auto
-            cores = 0
-            http-connections = 128
-            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6
@@ -177,17 +166,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-        with:
-          # Build parallelism + substituter tuning. max-jobs runs independent
-          # derivations concurrently and cores=0 lets each build use all CPUs;
-          # bumping http-connections / max-substitution-jobs widens the binary
-          # cache fetch pipeline so restoring the closure isn't bottlenecked on
-          # the default 25 connections / 16 parallel substitutions.
-          extra-conf: |
-            max-jobs = auto
-            cores = 0
-            http-connections = 128
-            max-substitution-jobs = 32
 
       - name: Cache Nix store
         uses: nix-community/cache-nix-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,6 +181,13 @@ jobs:
       # job-level env above.
       - name: Build images
         id: build
+        env:
+          # These are verification images, not shipped artifacts, so trade ISO
+          # size for build speed: a low squashfs compression level is far faster
+          # than the nixpkgs default (zstd level 19), which otherwise dominates
+          # the build — and the rev baked into /etc forces that recompress on
+          # every commit regardless of caching. Releases keep the slow default.
+          ISO_COMPRESSION: zstd -Xcompression-level 3
         run: |
           # Record the per-kind plan in the run summary for quick scanning.
           plan() { [ "$1" = "true" ] && echo "full ISO" || echo "derivation only"; }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,20 +5,13 @@
 # bad references / type errors surface fast; the matrix build jobs then realise
 # (or, drv-only, just instantiate) the images.
 #
-# Each arch builds on a native runner; the build itself runs inside the
-# official `nixos/nix` container via `docker run`. We deliberately do NOT put
-# the whole job in `container:` — the nixos/nix image lacks a standard glibc
-# loader, so GitHub's bundled Node can't run there and every JS action
-# (checkout, upload-artifact) fails with `exec .../node: no such file or
-# directory`. So checkout/upload run on the host runner and only `make` runs in
-# the container.
-#
-# One job per arch builds BOTH kinds in the SAME container (installer first,
-# appliance second). `make <kind>/iso` resolves to the runner's native
-# `builtins.currentSystem` and produces
-# out/<kind>-iso/iso/coder-box-<kind>-<arch>-linux.iso (+ a .sha256 sidecar);
-# the container /nix/store is ephemeral, so we dereference the ISOs into a host
-# /dist volume and upload from there.
+# Nix is installed natively on each runner (cachix/install-nix-action) rather
+# than run from the `nixos/nix` container — that container lacks a standard
+# glibc loader, so GitHub's bundled Node couldn't run there and JS actions
+# failed; installing on the host avoids that entirely and, crucially, lets us
+# cache the /nix/store across runs (nix-community/cache-nix-action, backed by
+# the GitHub Actions cache). Each arch builds on its own native runner, so
+# `make <kind>/iso` resolves to the runner's native `builtins.currentSystem`.
 #
 # Triggers / what gets built per kind:
 #   * push to main                     → drv-only: just instantiate each kind's
@@ -66,10 +59,8 @@ jobs:
   # --all-systems` evaluates every flake output (nixosConfigurations, packages,
   # …) for all declared systems (x86_64 + aarch64), catching typos / bad
   # references / type errors in seconds. The per-kind ISO derivations are
-  # instantiated separately by the `iso` job below (its drv-only path), so this
-  # covers the flake outputs that path doesn't touch. Runs inside the nixos/nix
-  # container via `docker run` (that image lacks a glibc loader for GitHub's
-  # bundled Node, so the checkout JS action stays on the host runner).
+  # instantiated separately by the `Images` job below (its drv-only path), so
+  # this covers the flake outputs that path doesn't touch.
   flake:
     name: Flake eval
     runs-on: ubuntu-24.04
@@ -79,16 +70,24 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # Key on the lockfile + all Nix sources; restore the most recent
+          # arch-matching cache otherwise. Cap the saved store so a run can't
+          # blow past the repo's GitHub Actions cache budget.
+          primary-key: nix-flake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-flake-${{ runner.os }}-${{ runner.arch }}-
+          gc-max-store-size-linux: 5G
+
       - name: nix flake check
-        run: |
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            nixos/nix:latest \
-            sh -euc '
-              export NIX_CONFIG="experimental-features = nix-command flakes"
-              git config --global --add safe.directory /work
-              nix flake check --impure --no-build --all-systems
-            '
+        run: nix flake check --impure --no-build --all-systems
 
   # Tiny pre-job that decides, per kind, whether to build the full ISO or just
   # instantiate the derivation, and assembles a short human title for the build
@@ -167,6 +166,21 @@ jobs:
           # dispatch to build an arbitrary commit.
           ref: ${{ github.event.inputs.ref }}
 
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # ISO closures are large; cap the saved store so a build can't blow
+          # past the repo's GitHub Actions cache budget (10G total).
+          primary-key: nix-images-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('flake.lock', '**/*.nix') }}
+          restore-prefixes-first-match: nix-images-${{ runner.os }}-${{ runner.arch }}-
+          gc-max-store-size-linux: 8G
+
       # Per-kind plan (full ISO vs drv only) is in the job name; the run summary
       # below also records it. INSTALLER_FULL / APPLIANCE_FULL come from the
       # job-level env above.
@@ -180,43 +194,29 @@ jobs:
             echo "- installer: $(plan "$INSTALLER_FULL")"
             echo "- appliance: $(plan "$APPLIANCE_FULL")"
           } >>"$GITHUB_STEP_SUMMARY"
-          # Host /dist volume, bind-mounted into the container, where full builds
-          # drop the finished ISO + checksum (the container's /nix/store is
-          # ephemeral, so the in-tree out/ symlink would dangle on the host).
+
+          # Nix is on the host now, so make/git (preinstalled on the runner)
+          # build straight into the host /nix/store — no container. A full build
+          # → make <kind>/iso, then dereference the image + its .sha256 sidecar
+          # (colocated in out/<kind>-iso/iso) into a real dir for upload; a
+          # drv-only kind just instantiates. Bare target → native currentSystem.
           dist="$(mktemp -d)"
           echo "dist=$dist" >>"$GITHUB_OUTPUT"
-          # Both kinds run in ONE container; installer first, appliance later.
-          docker run --rm \
-            -v "$PWD":/work -w /work \
-            -v "$dist":/dist \
-            -e INSTALLER_FULL -e APPLIANCE_FULL -e CODER_BOX_PR_TITLE -e CODER_BOX_PR_NUMBER \
-            nixos/nix:latest \
-            sh -euc '
-              # The Makefile builds via "nix build --impure" and needs flakes +
-              # nix-command, which the nixos/nix image does not enable by default.
-              export NIX_CONFIG="experimental-features = nix-command flakes"
-              # Repo is bind-mounted and owned by a different uid; allow git to
-              # read it so the Makefile can stamp the build rev.
-              git config --global --add safe.directory /work
-
-              # full build → realise the ISO; make puts the image (symlink) and
-              # its .sha256 sidecar together in out/<kind>-iso/iso, so a single
-              # cp -L grabs both into /dist. Otherwise just instantiate the
-              # derivation. Bare target → native currentSystem (matrix pins the
-              # runner arch). gnumake provides "make"; git stamps the build rev.
-              build_kind() {
-                kind="$1"; full="$2"
-                if [ "$full" = "true" ]; then
-                  nix-shell -p gnumake git --run "make $kind/iso"
-                  cp -L "out/$kind-iso/iso"/* /dist/
-                else
-                  nix-shell -p gnumake git --run "make $kind/drv"
-                fi
-              }
-
-              build_kind installer "$INSTALLER_FULL"
-              build_kind appliance "$APPLIANCE_FULL"
-            '
+          # Nix is on the host (make/git preinstalled on the runner) so the
+          # build goes straight into the host /nix/store — no container. The
+          # job-level CODER_BOX_PR_TITLE / CODER_BOX_PR_NUMBER env is inherited
+          # by make directly (read under --impure for the pretty version name).
+          build_kind() {
+            kind="$1"; full="$2"
+            if [ "$full" = "true" ]; then
+              make "$kind/iso"
+              cp -L "out/$kind-iso/iso"/* "$dist/"
+            else
+              make "$kind/drv"
+            fi
+          }
+          build_kind installer "$INSTALLER_FULL"
+          build_kind appliance "$APPLIANCE_FULL"
           ls -lh "$dist"
 
       - name: Upload installer ISO artifact

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,15 @@ define box_instantiate
 	@echo
 endef
 
-.PHONY: installer/iso installer/drv appliance/iso appliance/drv appliance/qcow2 appliance/raw fmt fmt/check lint lint/fix
+.PHONY: check installer/iso installer/drv appliance/iso appliance/drv appliance/qcow2 appliance/raw fmt fmt/check lint lint/fix
+
+# ── check — flake evaluation (cheap; builds nothing) ──────────────────────────
+# `nix flake check --no-build --all-systems` evaluates every flake output
+# (nixosConfigurations, packages, …) for all declared systems, catching typos /
+# bad references / type errors in seconds without realising anything. --impure
+# matches the box_* helpers (currentSystem + the CODER_BOX_PR_* env reads).
+check:
+	$(NIX) flake check $(NIX_PERF_FLAGS) --impure --no-build --all-systems
 
 # installer/iso is listed first so it's the default goal (bare `make`).
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,15 @@ GIT_REV := $(shell git rev-parse HEAD 2>/dev/null)$(shell git diff-index --quiet
 # Normalize an arch token to a *-linux triple: $(call norm_arch,aarch64) -> aarch64-linux
 norm_arch = $(if $(filter %-linux,$(1)),$(1),$(1)-linux)
 
+# Optional squashfs compression override for ISO builds. Empty = the nixpkgs
+# default (zstd -Xcompression-level 19): maximum ratio, but the SLOWEST setting,
+# and it dominates ISO build time for the full GUI box. CI sets a fast level
+# (e.g. `make installer/iso ISO_COMPRESSION='zstd -Xcompression-level 3'`) to cut
+# build time at the cost of a slightly larger image; releases keep the default
+# so shipped ISOs stay small. Expands to the module field that box_iso injects.
+ISO_COMPRESSION ?=
+iso_comp_field = $(if $(ISO_COMPRESSION),isoImage.squashfsCompression = "$(ISO_COMPRESSION)";,)
+
 # Single build helper used by every target. extendModules lets us override
 # nixpkgs.hostPlatform (per-arch) and the disko image format from one recipe,
 # so adding a format/arch is just a thin target below — no duplicated nix
@@ -136,9 +145,9 @@ endef
 
 # ── installer/iso — installer ISO (hosts/_installer-iso); ISO only ────────────
 installer/iso:
-	$(call box_iso,_installer-iso,isoImageDir,,)
+	$(call box_iso,_installer-iso,isoImageDir,$(iso_comp_field),)
 installer/iso/%:
-	$(call box_iso,_installer-iso,isoImageDir,,$*)
+	$(call box_iso,_installer-iso,isoImageDir,$(iso_comp_field),$*)
 
 # ── installer/drv — instantiate the installer ISO derivation (no build) ───────
 installer/drv:
@@ -148,9 +157,9 @@ installer/drv/%:
 
 # ── appliance/iso — ephemeral appliance ISO (hosts/_appliance-iso) ───────────
 appliance/iso:
-	$(call box_iso,_appliance-iso,isoImageDir,,)
+	$(call box_iso,_appliance-iso,isoImageDir,$(iso_comp_field),)
 appliance/iso/%:
-	$(call box_iso,_appliance-iso,isoImageDir,,$*)
+	$(call box_iso,_appliance-iso,isoImageDir,$(iso_comp_field),$*)
 
 # ── appliance/drv — instantiate the appliance ISO derivation (no build) ───────
 appliance/drv:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,20 @@
 NIX   ?= nix
 FLAKE ?= .
 
+# Build parallelism + substituter tuning, applied to every Nix invocation
+# (build and eval) via NIX_PERF_FLAGS below. max-jobs runs independent
+# derivations concurrently and cores=0 lets each build use all CPUs;
+# http-connections / max-substitution-jobs widen the binary-cache fetch
+# pipeline (Nix defaults 25 / 16) so restoring a large closure isn't the
+# bottleneck. Override per-invocation, e.g. `make installer/iso NIX_MAX_JOBS=4`.
+NIX_MAX_JOBS         ?= auto
+NIX_CORES            ?= 0
+NIX_HTTP_CONNECTIONS ?= 128
+NIX_MAX_SUBST_JOBS   ?= 32
+NIX_PERF_FLAGS = --max-jobs $(NIX_MAX_JOBS) --cores $(NIX_CORES) \
+  --option http-connections $(NIX_HTTP_CONNECTIONS) \
+  --option max-substitution-jobs $(NIX_MAX_SUBST_JOBS)
+
 # Build revision injected into images (installer boot menu, /etc/coder-box-rev).
 # We build through a path flakeref (getFlake (toString ./.)), which carries no
 # git metadata, so self.rev/dirtyRev are empty — compute the rev here and pass
@@ -100,7 +114,7 @@ box_cfg = let f = builtins.getFlake (toString ./.); in (f.nixosConfigurations.$(
 
 define box_build
 	@mkdir -p out
-	$(NIX) build --impure --no-write-lock-file --print-out-paths \
+	$(NIX) build $(NIX_PERF_FLAGS) --impure --no-write-lock-file --print-out-paths \
 	  --out-link 'out/$(subst /,-,$@)' --expr \
 	  '$(call box_cfg,$(1),$(4),$(3)).$(2)'
 endef
@@ -134,7 +148,7 @@ endef
 # built output to anchor, and the .drv itself is a GC root until next gc.
 #   $(1) = host   $(2) = system.build.<attr>   $(3) = extra module fields   $(4) = arch token
 define box_instantiate
-	$(NIX) eval --impure --no-write-lock-file --raw --expr \
+	$(NIX) eval $(NIX_PERF_FLAGS) --impure --no-write-lock-file --raw --expr \
 	  '$(call box_cfg,$(1),$(4),$(3)).$(2).drvPath'
 	@echo
 endef


### PR DESCRIPTION
## What

Two related CI changes to `test.yml` and `release.yml`:

1. **Move away from `docker run`.** The workflows ran `make` inside the `nixos/nix:latest` container via `docker run`. That was only ever a workaround: putting the *whole* job in `container:` broke GitHub's bundled Node (the image lacks a standard glibc loader), so JS actions like `checkout`/`upload-artifact` failed. Installing Nix **directly on the host runner** (`cachix/install-nix-action`) removes the container — and the reason for it — entirely.
2. **Cache the `/nix/store`.** With Nix on the host, the store persists across steps, so `nix-community/cache-nix-action` (backed by the GitHub Actions cache) can save/restore it. Repeat eval/drv/ISO builds reuse the nixpkgs + dependency closure instead of re-fetching/re-building it.

## Why this is cleaner

The container approach needed a `/dist` bind-mount (the container `/nix/store` was ephemeral), an inline `NIX_CONFIG`, a `git config --global --add safe.directory` dance (bind-mount owned by another uid), and `nix-shell -p gnumake git`. On the host, `make`/`git` are preinstalled, the build writes straight to the host `/nix/store`, and `out/<kind>-iso/iso/` is a normal path — so a single `cp -L` dereferences the ISO + `.sha256` sidecar into a mktemp dir for upload. All that scaffolding is gone.

## Caching details

- `cachix/install-nix-action@v30` with `experimental-features = nix-command flakes`.
- `nix-community/cache-nix-action@v6`, keyed on `runner.os` + `runner.arch` + `hashFiles('flake.lock', '**/*.nix')`, with `restore-prefixes-first-match` for partial hits.
- `gc-max-store-size-linux` caps the saved store (5G for the eval job, 8G for the ISO builds) so a run can't blow past the repo's ~10G GitHub Actions cache budget. Keys are per-arch, so x86_64 and aarch64 caches don't collide.

## Validation
- Both workflows pass YAML parsing.
- No `docker run` / `nixos/nix` image / `/dist` bind-mount / `safe.directory` left (only an explanatory comment about *why* we moved off the container).

## Notes / things to watch on the first run
- `cache-nix-action` restores into `/nix/store`; the first run is a cold cache (no speedup), subsequent runs benefit.
- ISO closures are large — if the 8G cap proves too small/large for the real closure, it's a one-line tweak.
- aarch64 builds run on `ubuntu-24.04-arm`; `install-nix-action` + `cache-nix-action` both support arm64 Linux.