### PR TITLE
feat: add PR title to pretty version name in ISO name and menu entry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,6 +144,11 @@ jobs:
       # Resolved per-kind plan from the `plan` job. Steps below branch on these.
       INSTALLER_FULL: ${{ needs.plan.outputs.installer_full }}
       APPLIANCE_FULL: ${{ needs.plan.outputs.appliance_full }}
+      # PR title woven into the image's pretty version name (boot-menu label +
+      # ISO file name) via coderBox.prTitle. Set through `env:` (not inlined into
+      # a run script) so an arbitrary title can't break the shell, and empty for
+      # non-PR events so tag/main builds keep their plain names.
+      CODER_BOX_PR_TITLE: ${{ github.event.pull_request.title }}
     strategy:
       fail-fast: false
       matrix:
@@ -182,7 +187,7 @@ jobs:
           docker run --rm \
             -v "$PWD":/work -w /work \
             -v "$dist":/dist \
-            -e INSTALLER_FULL -e APPLIANCE_FULL \
+            -e INSTALLER_FULL -e APPLIANCE_FULL -e CODER_BOX_PR_TITLE \
             nixos/nix:latest \
             sh -euc '
               # The Makefile builds via "nix build --impure" and needs flakes +

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,11 +144,13 @@ jobs:
       # Resolved per-kind plan from the `plan` job. Steps below branch on these.
       INSTALLER_FULL: ${{ needs.plan.outputs.installer_full }}
       APPLIANCE_FULL: ${{ needs.plan.outputs.appliance_full }}
-      # PR title woven into the image's pretty version name (boot-menu label +
-      # ISO file name) via coderBox.prTitle. Set through `env:` (not inlined into
-      # a run script) so an arbitrary title can't break the shell, and empty for
-      # non-PR events so tag/main builds keep their plain names.
+      # PR title + number woven into the image's pretty version name (boot-menu
+      # label + ISO file name) via coderBox.prTitle / coderBox.prNumber. Set
+      # through `env:` (not inlined into a run script) so an arbitrary title
+      # can't break the shell, and empty for non-PR events so tag/main builds
+      # keep their plain names.
       CODER_BOX_PR_TITLE: ${{ github.event.pull_request.title }}
+      CODER_BOX_PR_NUMBER: ${{ github.event.pull_request.number }}
     strategy:
       fail-fast: false
       matrix:
@@ -187,7 +189,7 @@ jobs:
           docker run --rm \
             -v "$PWD":/work -w /work \
             -v "$dist":/dist \
-            -e INSTALLER_FULL -e APPLIANCE_FULL -e CODER_BOX_PR_TITLE \
+            -e INSTALLER_FULL -e APPLIANCE_FULL -e CODER_BOX_PR_TITLE -e CODER_BOX_PR_NUMBER \
             nixos/nix:latest \
             sh -euc '
               # The Makefile builds via "nix build --impure" and needs flakes +

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ FLAKE ?= .
 # checkout (the module then falls back to self.rev / "unknown").
 GIT_REV := $(shell git rev-parse HEAD 2>/dev/null)$(shell git diff-index --quiet HEAD -- 2>/dev/null || echo -dirty)
 
+# Optional PR title woven into the image's pretty version name (boot-menu label
+# + ISO file name) via coderBox.prTitle. Not injected through the Nix expression
+# (an arbitrary title would need shell-escaping); instead the option reads the
+# CODER_BOX_PR_TITLE environment variable under `--impure` (which box_cfg already
+# uses). CI sets it for PR builds; locally you can preview with e.g.
+#   CODER_BOX_PR_TITLE="fix the thing" make installer/iso
+# Unset → plain names (the option defaults to "").
+
 # Normalize an arch token to a *-linux triple: $(call norm_arch,aarch64) -> aarch64-linux
 norm_arch = $(if $(filter %-linux,$(1)),$(1),$(1)-linux)
 

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,14 @@ FLAKE ?= .
 # checkout (the module then falls back to self.rev / "unknown").
 GIT_REV := $(shell git rev-parse HEAD 2>/dev/null)$(shell git diff-index --quiet HEAD -- 2>/dev/null || echo -dirty)
 
-# Optional PR title woven into the image's pretty version name (boot-menu label
-# + ISO file name) via coderBox.prTitle. Not injected through the Nix expression
-# (an arbitrary title would need shell-escaping); instead the option reads the
-# CODER_BOX_PR_TITLE environment variable under `--impure` (which box_cfg already
-# uses). CI sets it for PR builds; locally you can preview with e.g.
-#   CODER_BOX_PR_TITLE="fix the thing" make installer/iso
-# Unset → plain names (the option defaults to "").
+# Optional PR title + number woven into the image's pretty version name
+# (boot-menu label + ISO file name) via coderBox.prTitle / coderBox.prNumber.
+# Not injected through the Nix expression (an arbitrary title would need
+# shell-escaping); instead the options read the CODER_BOX_PR_TITLE /
+# CODER_BOX_PR_NUMBER environment variables under `--impure` (which box_cfg
+# already uses). CI sets them for PR builds; locally you can preview with e.g.
+#   CODER_BOX_PR_TITLE="fix the thing" CODER_BOX_PR_NUMBER=46 make installer/iso
+# Unset → plain names (the options default to "").
 
 # Normalize an arch token to a *-linux triple: $(call norm_arch,aarch64) -> aarch64-linux
 norm_arch = $(if $(filter %-linux,$(1)),$(1),$(1)-linux)

--- a/nixos/_images/appliance/iso.nix
+++ b/nixos/_images/appliance/iso.nix
@@ -20,7 +20,12 @@
 # admin bootstrap) lives in ../box-turnkey.nix. This module only sets the
 # appliance's image identity.
 
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   imports = [

--- a/nixos/_images/appliance/iso.nix
+++ b/nixos/_images/appliance/iso.nix
@@ -20,7 +20,7 @@
 # admin bootstrap) lives in ../box-turnkey.nix. This module only sets the
 # appliance's image identity.
 
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   imports = [
@@ -33,12 +33,16 @@
   # Boot-menu label (both the BIOS/isolinux and EFI/grub entries). The label is
   # "<distroName> <version><appendToMenuLabel>"; the default append is
   # " Installer", which is misleading here since this is the appliance, not the
-  # installer. Leading space is required (it's concatenated directly).
-  isoImage.appendToMenuLabel = " - Coder Box Appliance";
+  # installer. Leading space is required (it's concatenated directly). The
+  # PR-title suffix (coderBox.prMenuSuffix, set in box-turnkey.nix) is empty
+  # unless this is a PR preview build.
+  isoImage.appendToMenuLabel = " - Coder Box Appliance${config.coderBox.prMenuSuffix}";
   # ISO file name. iso-image.nix derives isoName from image.baseName as
   # "<baseName>.iso", and defaults baseName to "nixos-<version>-<arch>". We
   # override baseName (mkForce, to win over that default) but keep the arch
   # suffix so the file is e.g. coder-box-appliance-aarch64-linux.iso — the arch
-  # is visible in the name and x86_64/aarch64 ISOs don't collide in ./out.
-  image.baseName = lib.mkForce "coder-box-appliance-${pkgs.stdenv.hostPlatform.system}";
+  # is visible in the name and x86_64/aarch64 ISOs don't collide in ./out. The
+  # PR-slug suffix (coderBox.prFileSuffix) is empty unless this is a PR preview
+  # build (e.g. coder-box-appliance-x86_64-linux-pr-fix-the-thing.iso).
+  image.baseName = lib.mkForce "coder-box-appliance-${pkgs.stdenv.hostPlatform.system}${config.coderBox.prFileSuffix}";
 }

--- a/nixos/_images/box-turnkey.nix
+++ b/nixos/_images/box-turnkey.nix
@@ -20,6 +20,36 @@
   ...
 }:
 
+let
+  # ── Pretty version name helpers ──────────────────────────────────────────────
+  # The "pretty version name" is the human-facing identity woven into the boot
+  # menu label and the ISO file name. For a PR preview build CI injects the PR
+  # title (coderBox.prTitle); when present it is appended so reviewers can tell
+  # at a glance which PR an image came from. Empty for tag/main/local builds.
+  prTitle = config.coderBox.prTitle;
+
+  # Boot-menu form: keep the raw title but neutralise the few characters that
+  # would break the generated isolinux/grub menu (quotes, backslashes, newlines).
+  menuTitle = builtins.replaceStrings [ "\n" "\"" "\\" ] [ " " "'" "" ] prTitle;
+
+  # File-name form: lowercase the title and reduce it to a [a-z0-9-] slug so the
+  # ISO name stays portable. Collapse dash runs, trim edges, and cap the length
+  # so the file name doesn't balloon for a long PR title.
+  slugify = title:
+    let
+      lower = lib.toLower title;
+      safe  = lib.concatMapStrings
+        (c: if builtins.match "[a-z0-9]" c != null then c else "-")
+        (lib.stringToCharacters lower);
+      collapse = s:
+        let r = builtins.replaceStrings [ "--" ] [ "-" ] s;
+        in if r == s then s else collapse r;
+      capped = let c = collapse safe;
+               in if builtins.stringLength c > 40 then builtins.substring 0 40 c else c;
+    in lib.removeSuffix "-" (lib.removePrefix "-" capped);
+
+  prSlug = slugify prTitle;
+in
 {
   imports = [
     # Broad driver/firmware set so the image boots on arbitrary hardware /
@@ -44,6 +74,37 @@
     type = lib.types.str;
     default = self.rev or self.dirtyRev or "unknown";
     description = "Git revision this Coder box image was built from.";
+  };
+
+  # PR title for a pull-request preview build. CI sets it via the
+  # CODER_BOX_PR_TITLE environment variable (read here under `--impure`, which
+  # every image build already uses), so an arbitrary title never has to be
+  # shell-escaped into a Nix expression. getEnv returns "" in pure eval / when
+  # unset, so non-PR builds (tags, main, local `nix build`) leave the pretty
+  # version name untouched.
+  options.coderBox.prTitle = lib.mkOption {
+    type        = lib.types.str;
+    default     = builtins.getEnv "CODER_BOX_PR_TITLE";
+    description = "Pull-request title this image was built for, woven into the pretty version name (boot-menu label + ISO file name) when non-empty.";
+  };
+
+  # Derived, read-only fragments so every image flavour appends the PR identity
+  # the same way. coderBox.prMenuSuffix goes on the boot-menu label;
+  # coderBox.prFileSuffix goes on the ISO file name. Both are empty when there's
+  # no PR title, so they're safe to interpolate unconditionally.
+  options.coderBox.prMenuSuffix = lib.mkOption {
+    type        = lib.types.str;
+    internal    = true;
+    readOnly    = true;
+    default     = lib.optionalString (prTitle != "") " - PR: ${menuTitle}";
+    description = "Boot-menu label fragment naming the PR this image was built for (empty for non-PR builds).";
+  };
+  options.coderBox.prFileSuffix = lib.mkOption {
+    type        = lib.types.str;
+    internal    = true;
+    readOnly    = true;
+    default     = lib.optionalString (prSlug != "") "-pr-${prSlug}";
+    description = "ISO file-name fragment naming the PR this image was built for (empty for non-PR builds).";
   };
 
   config = {

--- a/nixos/_images/box-turnkey.nix
+++ b/nixos/_images/box-turnkey.nix
@@ -13,6 +13,7 @@
 # override per-image via hosts/<host>/local.nix.
 
 {
+  config,
   lib,
   pkgs,
   self,
@@ -26,7 +27,7 @@ let
   # menu label and the ISO file name. For a PR preview build CI injects the PR
   # title (coderBox.prTitle); when present it is appended so reviewers can tell
   # at a glance which PR an image came from. Empty for tag/main/local builds.
-  prTitle = config.coderBox.prTitle;
+  inherit (config.coderBox) prTitle;
 
   # Boot-menu form: keep the raw title but neutralise the few characters that
   # would break the generated isolinux/grub menu (quotes, backslashes, newlines).
@@ -35,20 +36,35 @@ let
   # File-name form: lowercase the title and reduce it to a [a-z0-9-] slug so the
   # ISO name stays portable. Collapse dash runs, trim edges, and cap the length
   # so the file name doesn't balloon for a long PR title.
-  slugify = title:
+  slugify =
+    title:
     let
       lower = lib.toLower title;
-      safe  = lib.concatMapStrings
-        (c: if builtins.match "[a-z0-9]" c != null then c else "-")
-        (lib.stringToCharacters lower);
-      collapse = s:
-        let r = builtins.replaceStrings [ "--" ] [ "-" ] s;
-        in if r == s then s else collapse r;
-      capped = let c = collapse safe;
-               in if builtins.stringLength c > 40 then builtins.substring 0 40 c else c;
-    in lib.removeSuffix "-" (lib.removePrefix "-" capped);
+      safe = lib.concatMapStrings (c: if builtins.match "[a-z0-9]" c != null then c else "-") (
+        lib.stringToCharacters lower
+      );
+      collapse =
+        s:
+        let
+          r = builtins.replaceStrings [ "--" ] [ "-" ] s;
+        in
+        if r == s then s else collapse r;
+      capped =
+        let
+          c = collapse safe;
+        in
+        if builtins.stringLength c > 40 then builtins.substring 0 40 c else c;
+    in
+    lib.removeSuffix "-" (lib.removePrefix "-" capped);
 
   prSlug = slugify prTitle;
+
+  # PR number (the GitHub PR "ID"). CI injects it alongside the title; included
+  # in both the menu label ("#46") and the file name ("-46") when present so an
+  # image can be traced straight back to its PR. Empty for non-PR builds.
+  inherit (config.coderBox) prNumber;
+  prNumMenu = lib.optionalString (prNumber != "") " #${prNumber}";
+  prNumFile = lib.optionalString (prNumber != "") "-${prNumber}";
 in
 {
   imports = [
@@ -83,27 +99,36 @@ in
   # unset, so non-PR builds (tags, main, local `nix build`) leave the pretty
   # version name untouched.
   options.coderBox.prTitle = lib.mkOption {
-    type        = lib.types.str;
-    default     = builtins.getEnv "CODER_BOX_PR_TITLE";
+    type = lib.types.str;
+    default = builtins.getEnv "CODER_BOX_PR_TITLE";
     description = "Pull-request title this image was built for, woven into the pretty version name (boot-menu label + ISO file name) when non-empty.";
+  };
+
+  # PR number (GitHub PR "ID") for a pull-request preview build. CI sets it via
+  # CODER_BOX_PR_NUMBER (read under `--impure` like prTitle); empty otherwise.
+  options.coderBox.prNumber = lib.mkOption {
+    type = lib.types.str;
+    default = builtins.getEnv "CODER_BOX_PR_NUMBER";
+    description = "Pull-request number (ID) this image was built for, woven into the pretty version name when non-empty.";
   };
 
   # Derived, read-only fragments so every image flavour appends the PR identity
   # the same way. coderBox.prMenuSuffix goes on the boot-menu label;
-  # coderBox.prFileSuffix goes on the ISO file name. Both are empty when there's
-  # no PR title, so they're safe to interpolate unconditionally.
+  # coderBox.prFileSuffix goes on the ISO file name. Both carry the PR number
+  # ("#46" / "-46") when known, and are empty when there's no PR title, so
+  # they're safe to interpolate unconditionally.
   options.coderBox.prMenuSuffix = lib.mkOption {
-    type        = lib.types.str;
-    internal    = true;
-    readOnly    = true;
-    default     = lib.optionalString (prTitle != "") " - PR: ${menuTitle}";
+    type = lib.types.str;
+    internal = true;
+    readOnly = true;
+    default = lib.optionalString (prTitle != "") " - PR${prNumMenu}: ${menuTitle}";
     description = "Boot-menu label fragment naming the PR this image was built for (empty for non-PR builds).";
   };
   options.coderBox.prFileSuffix = lib.mkOption {
-    type        = lib.types.str;
-    internal    = true;
-    readOnly    = true;
-    default     = lib.optionalString (prSlug != "") "-pr-${prSlug}";
+    type = lib.types.str;
+    internal = true;
+    readOnly = true;
+    default = lib.optionalString (prSlug != "") "-pr${prNumFile}-${prSlug}";
     description = "ISO file-name fragment naming the PR this image was built for (empty for non-PR builds).";
   };
 

--- a/nixos/_images/installer/iso.nix
+++ b/nixos/_images/installer/iso.nix
@@ -73,10 +73,16 @@ in
     isoImage.volumeID = "CODER_BOX_INSTALLER";
     # Boot-menu label (BIOS/isolinux + EFI/grub). See ../appliance/iso.nix for
     # the format; leading space is required. Include the short build revision so
-    # the boot menu shows exactly which image you're booting. The PR-title
-    # suffix (coderBox.prMenuSuffix, set in box-turnkey.nix) is empty unless this
-    # is a PR preview build.
-    isoImage.appendToMenuLabel = " - Coder Box Installer (${boxRevShort})${config.coderBox.prMenuSuffix}";
+    # the boot menu shows exactly which image you're booting. For a PR preview
+    # build (coderBox.prMenuSuffix non-empty) the PR reference comes first and
+    # the commit hash moves to the very end, so the label reads
+    # " - Coder Box Installer - PR #46: <title> (<rev>)"; otherwise it's just
+    # " - Coder Box Installer (<rev>)".
+    isoImage.appendToMenuLabel =
+      if config.coderBox.prMenuSuffix != "" then
+        " - Coder Box Installer${config.coderBox.prMenuSuffix} (${boxRevShort})"
+      else
+        " - Coder Box Installer (${boxRevShort})";
 
     # Record the full build revision for install.sh to print (the baked repo
     # under /etc/nixos-repo has no .git, so the script can't get it from git).

--- a/nixos/_images/installer/iso.nix
+++ b/nixos/_images/installer/iso.nix
@@ -73,16 +73,20 @@ in
     isoImage.volumeID = "CODER_BOX_INSTALLER";
     # Boot-menu label (BIOS/isolinux + EFI/grub). See ../appliance/iso.nix for
     # the format; leading space is required. Include the short build revision so
-    # the boot menu shows exactly which image you're booting.
-    isoImage.appendToMenuLabel = " - Coder Box Installer (${boxRevShort})";
+    # the boot menu shows exactly which image you're booting. The PR-title
+    # suffix (coderBox.prMenuSuffix, set in box-turnkey.nix) is empty unless this
+    # is a PR preview build.
+    isoImage.appendToMenuLabel = " - Coder Box Installer (${boxRevShort})${config.coderBox.prMenuSuffix}";
 
     # Record the full build revision for install.sh to print (the baked repo
     # under /etc/nixos-repo has no .git, so the script can't get it from git).
     environment.etc."coder-box-rev".text = boxRev + "\n";
 
     # ISO file name, with arch suffix (e.g. coder-box-installer-x86_64-linux.iso).
-    # See ../appliance/iso.nix for why this is mkForce + arch-suffixed.
-    image.baseName = lib.mkForce "coder-box-installer-${pkgs.stdenv.hostPlatform.system}";
+    # See ../appliance/iso.nix for why this is mkForce + arch-suffixed. The
+    # PR-slug suffix (coderBox.prFileSuffix) is empty unless this is a PR preview
+    # build (e.g. coder-box-installer-x86_64-linux-pr-fix-the-thing.iso).
+    image.baseName = lib.mkForce "coder-box-installer-${pkgs.stdenv.hostPlatform.system}${config.coderBox.prFileSuffix}";
 
     # ── Auto-launch a full-screen Konsole that runs the installer ──────────────
     # box-turnkey.nix autologins straight into the Plasma (X11) desktop. For the


### PR DESCRIPTION
Closes #42.

## What

When a build is for a pull request, weave the **PR title and number** into the image's **pretty version name** — both the **boot-menu label** (BIOS/isolinux + EFI/grub) and the **ISO file name** — so reviewers can tell at a glance which PR an image came from.

## How

- **`nixos/_images/box-turnkey.nix`** (shared by all image flavours) is the single source of truth:
  - `coderBox.prTitle` (from `CODER_BOX_PR_TITLE`) and `coderBox.prNumber` (from `CODER_BOX_PR_NUMBER`). Reading from the env (the build already runs `--impure`) means an arbitrary title never has to be shell-escaped into a Nix expression; `getEnv` returns `""` in pure eval / when unset, so tag/main/local builds are unaffected.
  - Two derived, read-only fragments so every flavour appends identically:
    - `prMenuSuffix` → `" - PR #46: <title>"` (number omitted if unknown), with menu-breaking chars (quotes, backslashes, newlines) neutralised.
    - `prFileSuffix` → `"-pr-46-<slug>"`, where `<slug>` is the lowercased title reduced to `[a-z0-9-]` (dash runs collapsed, edges trimmed, capped at 40 chars).
- **`installer/iso.nix`**: for a PR build the PR reference comes first and the **commit hash moves to the very end** of the boot-menu label; non-PR builds keep the plain `(<rev>)` form.
- **`appliance/iso.nix`**: appends the PR suffix (no rev in its label).
- **`.github/workflows/test.yml`** sets `CODER_BOX_PR_TITLE` / `CODER_BOX_PR_NUMBER` from the PR event (job-level `env:`, forwarded with `-e`) so the title can't break the shell; empty for non-PR events.
- **`Makefile`** documents the local preview override.

## Examples

Installer, PR #46 title `fix: the thing! (v2)`:
- ISO: `coder-box-installer-x86_64-linux-pr-46-fix-the-thing-v2.iso`
- Menu: ` - Coder Box Installer - PR #46: fix: the thing! (v2) (abc123def456)`

No PR (tag/main/local) — unchanged:
- ISO: `coder-box-installer-x86_64-linux.iso`
- Menu: ` - Coder Box Installer (abc123def456)`

## Validation

- `nix flake check --impure --no-build --all-systems` → all checks passed.
- Evaluated `isoImage.isoName` / `appendToMenuLabel` for installer + appliance, with/without PR title and with/without PR number, confirming the names above.