### PR TITLE
feat(images): generate .sha256 sidecars for appliance qcow2/raw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,17 @@ define box_iso
 	@for sha in 'out/$(subst /,-,$@)'/iso/*.iso.sha256; do cat "$$sha"; done
 endef
 
+# Disk-image build helper: box_build with the `diskoImagesDir` build product,
+# which is the disk image bundled with its SHA-256 sidecar in one store output
+# (see nixos/_images/base/disk.nix). So `--out-link` surfaces out/<target>/ with
+# both <name>.<format> and <name>.<format>.sha256, and a single
+# `cp -L out/<target>/*` copies them together. After the build we log each
+# image's checksum. Same arg shape as box_build (callers pass $(2)=diskoImagesDir).
+define box_disk
+	$(call box_build,$(1),$(2),$(3),$(4))
+	@for sha in 'out/$(subst /,-,$@)'/*.sha256; do cat "$$sha"; done
+endef
+
 # Instantiate-only counterpart to box_build: same flake expr, but evaluates
 # `.drvPath` so Nix fully evaluates the config and writes the .drv to the store
 # WITHOUT realising the (multi-GB) image. Cheap CI validation that the Nix is
@@ -140,12 +151,12 @@ appliance/drv/%:
 
 # ── appliance/qcow2 — persistent disk image (hosts/_appliance-disk) ──────────
 appliance/qcow2:
-	$(call box_build,_appliance-disk,diskoImages,disko.imageBuilder.imageFormat = "qcow2";,)
+	$(call box_disk,_appliance-disk,diskoImagesDir,disko.imageBuilder.imageFormat = "qcow2";,)
 appliance/qcow2/%:
-	$(call box_build,_appliance-disk,diskoImages,disko.imageBuilder.imageFormat = "qcow2";,$*)
+	$(call box_disk,_appliance-disk,diskoImagesDir,disko.imageBuilder.imageFormat = "qcow2";,$*)
 
 # ── appliance/raw — persistent disk image, dd-able (hosts/_appliance-disk) ────
 appliance/raw:
-	$(call box_build,_appliance-disk,diskoImages,disko.imageBuilder.imageFormat = "raw";,)
+	$(call box_disk,_appliance-disk,diskoImagesDir,disko.imageBuilder.imageFormat = "raw";,)
 appliance/raw/%:
-	$(call box_build,_appliance-disk,diskoImages,disko.imageBuilder.imageFormat = "raw";,$*)
+	$(call box_disk,_appliance-disk,diskoImagesDir,disko.imageBuilder.imageFormat = "raw";,$*)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ image at `out/appliance-raw/coder-box-appliance-*.raw` (or
 `out/appliance-qcow2/coder-box-appliance-*.qcow2`). All names carry the arch,
 e.g. `coder-box-appliance-aarch64-linux.iso`.
 
+Every shipped image — ISO, qcow2, and raw — is built alongside a `<name>.sha256`
+sidecar in the same directory (`coder-box-appliance-*.iso.sha256`,
+`coder-box-appliance-*.qcow2.sha256`, etc.), so `sha256sum -c <name>.sha256`
+verifies the image and `cp -L out/<target>/*` (or `.../iso/*` for ISOs) copies
+image + checksum together. The build prints each checksum when it finishes.
+
 The turn-key login + Coder admin bootstrap shared by all image flavours live in
 [`nixos/_images/box-turnkey.nix`](nixos/_images/box-turnkey.nix): autologin to the `coderbox`
 desktop, and admin `admin@coder.com` / `PleaseChangeMe1234`. Coder comes up at

--- a/hosts/_appliance-disk/default.nix
+++ b/hosts/_appliance-disk/default.nix
@@ -13,8 +13,10 @@
 #   make appliance/raw                   # raw  (dd-able straight to a drive)
 #   make appliance/qcow2/aarch64-linux   # cross-arch (needs a matching builder)
 #
-#   # without make, e.g. a raw image:
-#   nix build .#nixosConfigurations._appliance-disk.config.system.build.diskoImages
+#   # without make, e.g. a raw image (diskoImagesDir bundles the image with its
+#   # .sha256 sidecar, see nixos/_images/base/disk.nix; use .diskoImages for the
+#   # bare image without a checksum):
+#   nix build .#nixosConfigurations._appliance-disk.config.system.build.diskoImagesDir
 #   # (override disko.imageBuilder.imageFormat = "qcow2" for qcow2)
 #
 # This host is independent of install.sh; it shares the disk LAYOUT with
@@ -28,6 +30,7 @@
   imports = [
     ../../nixos/disko-standard.nix       # 1 GB ESP + ZFS root pool single-disk layout
     ../../nixos/_images/box-turnkey.nix  # shared turn-key config (login + Coder bootstrap)
+    ../../nixos/_images/base/disk.nix    # bundles each disk image with its .sha256 (diskoImagesDir)
   ] ++ lib.optional (builtins.pathExists ./local.nix) ./local.nix;
 
   # No networking.hostName here on purpose: underscore-prefixed image hosts get

--- a/nixos/_images/base/disk.nix
+++ b/nixos/_images/base/disk.nix
@@ -1,0 +1,29 @@
+# Shared disk-image mechanics for every Coder box image that ships as a
+# persistent disk image (qcow2 / raw). Mirrors base/iso.nix: that module bundles
+# each ISO with a .sha256 sidecar in the (immutable) /nix/store; this one does
+# the same for disko's disk images, so every shipped image — ISO or disk — gets
+# a checksum the same way.
+#
+# Consumes disko's `config.system.build.diskoImages` (a store directory holding
+# one `<imageName>.<format>` file per disk, see hosts/_appliance-disk) and
+# exposes `config.system.build.diskoImagesDir`.
+{ config, lib, pkgs, ... }:
+{
+  # A store output that bundles each disk image together with its SHA-256
+  # checksum, so the checksum lives in the (immutable) /nix/store right beside
+  # the image — exactly like base/iso.nix's isoImageDir does for ISOs. A plain
+  # `nix build --out-link out/<target>` then surfaces both. The image is
+  # symlinked (not copied) to avoid duplicating the multi-GB image; the
+  # interpolation registers it as a runtime dependency so it is GC-rooted along
+  # with this output. The checksum is written with the bare basename so
+  # `sha256sum -c <name>.sha256` verifies the image sitting next to it, and a
+  # single `cp -L out/<target>/*` copies image + sidecar together.
+  system.build.diskoImagesDir = pkgs.runCommand "coder-box-disk-with-checksum" { } ''
+    mkdir -p "$out"
+    for img in ${config.system.build.diskoImages}/*; do
+      base=$(basename "$img")
+      ln -s "$img" "$out/$base"
+      ( cd "$out" && sha256sum "$base" > "$base.sha256" )
+    done
+  '';
+}


### PR DESCRIPTION
## Problem

The installer ISO and appliance ISO both bundle each image with a `.sha256` checksum via `system.build.isoImageDir` (`nixos/_images/base/iso.nix`), surfaced by the `box_iso` Makefile helper. The appliance **disk** images (`qcow2`/`raw`) instead used the bare `box_build` + disko `diskoImages` path with **no checksum step**, so they shipped without a hash file.

Fixes #42.

## Changes

Mirror the proven ISO checksum pattern for disk images:

- **`nixos/_images/base/disk.nix`** (new) — analogous to `base/iso.nix`. Defines `system.build.diskoImagesDir`, a `runCommand` that symlinks each disko image and writes a `<name>.sha256` sidecar beside it in the immutable store, using the bare basename so `sha256sum -c <name>.sha256` works.
- **`hosts/_appliance-disk/default.nix`** — imports the new module; usage-example comment updated to `diskoImagesDir`.
- **`Makefile`** — adds a `box_disk` helper (disk counterpart to `box_iso`) and routes `appliance/qcow2`, `appliance/raw`, and their arch variants through `diskoImagesDir`, printing each checksum on completion.
- **`README.md`** — documents that every shipped image (ISO, qcow2, raw) now ships a `.sha256` sidecar.

After a build, `out/<target>/` contains both the image and its `.sha256`, so `cp -L out/<target>/*` copies them together.

## Validation

- `nix eval ... diskoImagesDir.drvPath` evaluates cleanly.
- `make -n appliance/qcow2` and `make -n appliance/raw/aarch64` expand correctly (build `diskoImagesDir`, then glob `out/<target>/*.sha256`).
- Full multi-GB qcow2/raw realization (QEMU/KVM VM build) was not run; the shell logic is identical to the already-proven `iso.nix` path. CI builds/publishes only ISOs, so no workflow changes were needed.
