### PR TITLE
ci: readable Nix logs + clear upload-artifact Node 20 warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,14 @@ concurrency:
   group: release-${{ github.event.inputs.tag || github.ref }}
   cancel-in-progress: false
 
+env:
+  # Force plain, greppable Nix output in CI logs. Nix's default animated
+  # multi-line progress bar renders as unreadable ANSI redraw noise in the
+  # GitHub Actions log viewer; `--log-format raw` prints one line per event and
+  # `--print-build-logs` streams the actual builder output. The Makefile passes
+  # $(NIX_OUTPUT_FLAGS) to every nix invocation (build / eval / flake check).
+  NIX_OUTPUT_FLAGS: --log-format raw --print-build-logs
+
 jobs:
   build:
     name: ${{ matrix.kind }} (${{ matrix.system }})
@@ -102,14 +110,14 @@ jobs:
           ls -lh "$dist"
 
       - name: Upload ISO artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coder-box-${{ matrix.target }}-${{ matrix.system }}
           path: ${{ steps.build.outputs.dist }}/*.iso
           if-no-files-found: error
 
       - name: Upload ISO checksum artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coder-box-${{ matrix.target }}-${{ matrix.system }}-sha256
           path: ${{ steps.build.outputs.dist }}/*.iso.sha256
@@ -134,7 +142,7 @@ jobs:
           echo "Releasing tag: $tag"
 
       - name: Download built ISOs
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,14 @@ concurrency:
   group: build-${{ github.ref }}-${{ github.event.inputs.ref }}
   cancel-in-progress: true
 
+env:
+  # Force plain, greppable Nix output in CI logs. Nix's default animated
+  # multi-line progress bar renders as unreadable ANSI redraw noise in the
+  # GitHub Actions log viewer; `--log-format raw` prints one line per event and
+  # `--print-build-logs` streams the actual builder output. The Makefile passes
+  # $(NIX_OUTPUT_FLAGS) to every nix invocation (build / eval / flake check).
+  NIX_OUTPUT_FLAGS: --log-format raw --print-build-logs
+
 jobs:
   # Flake evaluation — cheap, builds nothing. `nix flake check --no-build
   # --all-systems` evaluates every flake output (nixosConfigurations, packages,
@@ -228,7 +236,7 @@ jobs:
       # downloaded on its own. Each step runs only when its kind built full.
       - name: Upload installer ISO artifact
         if: env.INSTALLER_FULL == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coder-box-installer-${{ matrix.system }}
           path: |
@@ -240,7 +248,7 @@ jobs:
 
       - name: Upload appliance ISO artifact
         if: env.APPLIANCE_FULL == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coder-box-appliance-${{ matrix.system }}
           path: |

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,15 @@ NIX_PERF_FLAGS = --max-jobs $(NIX_MAX_JOBS) --cores $(NIX_CORES) \
   --option http-connections $(NIX_HTTP_CONNECTIONS) \
   --option max-substitution-jobs $(NIX_MAX_SUBST_JOBS)
 
+# Log output flags, applied to every Nix invocation. Empty by default so local
+# runs keep Nix's native interactive progress bar. In a non-interactive log
+# (GitHub Actions) that animated multi-line bar renders as unreadable ANSI
+# redraw noise, so CI sets e.g.
+#   NIX_OUTPUT_FLAGS='--log-format raw --print-build-logs'
+# to stream plain, greppable, one-line-per-event output (and the actual builder
+# logs) instead. Override per-invocation like the perf flags above.
+NIX_OUTPUT_FLAGS ?=
+
 # Build revision injected into images (installer boot menu, /etc/coder-box-rev).
 # We build through a path flakeref (getFlake (toString ./.)), which carries no
 # git metadata, so self.rev/dirtyRev are empty — compute the rev here and pass
@@ -114,7 +123,7 @@ box_cfg = let f = builtins.getFlake (toString ./.); in (f.nixosConfigurations.$(
 
 define box_build
 	@mkdir -p out
-	$(NIX) build $(NIX_PERF_FLAGS) --impure --no-write-lock-file --print-out-paths \
+	$(NIX) build $(NIX_PERF_FLAGS) $(NIX_OUTPUT_FLAGS) --impure --no-write-lock-file --print-out-paths \
 	  --out-link 'out/$(subst /,-,$@)' --expr \
 	  '$(call box_cfg,$(1),$(4),$(3)).$(2)'
 endef
@@ -148,7 +157,7 @@ endef
 # built output to anchor, and the .drv itself is a GC root until next gc.
 #   $(1) = host   $(2) = system.build.<attr>   $(3) = extra module fields   $(4) = arch token
 define box_instantiate
-	$(NIX) eval $(NIX_PERF_FLAGS) --impure --no-write-lock-file --raw --expr \
+	$(NIX) eval $(NIX_PERF_FLAGS) $(NIX_OUTPUT_FLAGS) --impure --no-write-lock-file --raw --expr \
 	  '$(call box_cfg,$(1),$(4),$(3)).$(2).drvPath'
 	@echo
 endef
@@ -161,7 +170,7 @@ endef
 # bad references / type errors in seconds without realising anything. --impure
 # matches the box_* helpers (currentSystem + the CODER_BOX_PR_* env reads).
 check:
-	$(NIX) flake check $(NIX_PERF_FLAGS) --impure --no-build --all-systems
+	$(NIX) flake check $(NIX_PERF_FLAGS) $(NIX_OUTPUT_FLAGS) --impure --no-build --all-systems
 
 # installer/iso is listed first so it's the default goal (bare `make`).
 


### PR DESCRIPTION
Addresses the CI annotation warnings and the unreadable Determinate/Nix build "timelines".

## What it fixes

### 1. Unreadable Nix build logs (the main ask)
Nix's default output is an **animated multi-line progress bar** that constantly redraws with ANSI carriage returns. In the GitHub Actions log viewer (no TTY, no redraw) that collapses into an unreadable wall of timeline/activity noise.

- New **`NIX_OUTPUT_FLAGS`** knob in the Makefile, threaded through *every* nix invocation (`box_build`, `box_instantiate`, `check`).
- **Empty by default**, so local `make installer/iso` keeps Nix's nice interactive progress bar.
- `test.yml` and `release.yml` set a workflow-level `env: NIX_OUTPUT_FLAGS: --log-format raw --print-build-logs`, so CI streams **plain, greppable, one-line-per-event** output plus the actual builder logs.

### 2. `Node.js 20 is deprecated` annotation (partial — the controllable part)
- `actions/upload-artifact` **v5 → v6** (test + release) and `actions/download-artifact` **v5 → v7** — both run on **Node.js 24**, clearing the deprecation annotation those actions emitted. v6/v7 are Node-24 bumps with no behavioral change for our usage; `download-artifact` keeps `merge-multiple`.

## Known residual warnings (upstream, not fixable here)

- **`nix-community/cache-nix-action@v6` Node 20 warning** — emitted by the runner for the action's own declared runtime. There is currently **no way to suppress it** from the workflow (even `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` doesn't, due to a runner ordering bug); it clears only when upstream bumps the action to Node 24. `v6` is already the latest major.
- **`Failed to restore: "/usr/bin/tar" ... exit code 2`** — a **non-fatal** quirk of `cache-nix-action` restoring into an already-populated `/nix/store` (it only happens once a cache exists, and does not fail the job). Left as-is to avoid risky churn; the cache still restores.

I scoped this PR to the two warnings we actually control plus the log-readability fix, and documented the rest honestly rather than papering over them.

## Validation
- All three workflow YAML files parse.
- `make --dry-run` confirms `--log-format raw --print-build-logs` is injected into `nix build`, `nix eval`, and `nix flake check` when `NIX_OUTPUT_FLAGS` is set, and that the default (unset) invocation stays clean.
- Verified `actions/upload-artifact@v6` / `download-artifact@v7` tags exist and run on Node 24; `merge-multiple` is still supported in download v7.
- Could not run a real `nix build` in the sandbox (unwritable store); runtime log formatting will be confirmed by this PR's CI run.