### PR TITLE
ci: don't run the image build job on main commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,8 +130,16 @@ jobs:
 
   # Job key is "Images" so the matrix shows as "Matrix: Images". `needs: plan`
   # also means these matrix jobs are skipped if the plan job fails.
+  #
+  # Skipped entirely on push to main: main commits never build full ISOs (only
+  # PRs with a test-*-iso label or manual dispatch do), and the drv-only
+  # instantiation this job would otherwise run is already covered by the
+  # `Flake eval` job (`nix flake check --all-systems` evaluates the same
+  # nixosConfigurations). So a main commit just runs the cheap flake check —
+  # no image build runners at all. PRs and workflow_dispatch still build.
   Images:
     needs: plan
+    if: github.event_name != 'push'
     # Short, readable name — the per-kind plan is computed by the `plan` job
     # above. e.g. "Build installer & appliance ISO (x86_64-linux)" or
     # "Build installer ISO & appliance DRV (aarch64-linux)".


### PR DESCRIPTION
## What

Skip the `Images` build job on push to `main`, so a main commit runs only the cheap `Flake eval`.

## Why

You flagged that ISOs shouldn't be built on main commits. They already aren't — the `plan` logic resolves both kinds to **drv-only** on push events (full ISOs only build on labelled PRs or `workflow_dispatch`). But the `Images` job was still spinning up **two runners per main commit** just to run the drv-only (`make <kind>/drv`) path.

That instantiation is **redundant**: the `Flake eval` job already runs `nix flake check --impure --no-build --all-systems`, which evaluates the same `nixosConfigurations._installer-iso` / `_appliance-iso` outputs. So building the drvs again on main adds nothing the flake check doesn't already cover.

## How

Add `if: github.event_name != 'push'` to the `Images` job. Net effect on a **main commit**: only `Flake eval` (+ the trivial `plan` job) runs — **no image build runners at all**. PRs and `workflow_dispatch` are unaffected and still build drvs (or full ISOs when labelled).

## Note on the label trigger

The other half of the original report (labels not retriggering CI) turned out to be a non-issue — `labeled` is already in the `pull_request` trigger types and verified working in run history (a `test-installer-iso` label on a ready PR produced a run that built `installer ISO & appliance DRV`). No change needed there.

## Validation

- `test.yml` YAML parses; `Images.if == github.event_name != 'push'`.
- Confirmed against run history that push-to-main currently builds DRV-only (no ISOs), so this only removes redundant drv runners on main — it doesn't change which ISOs get built anywhere.