### PR TITLE
chore(.github): add Renovate config for flake and actions updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,41 @@
+{
+  // Renovate config for coder/box. Runs via the Mend-hosted Renovate GitHub App
+  // (installed on the repo); no self-hosted workflow or token needed.
+  //
+  // Split by how risky an update is for a Nix flake:
+  //   * flake.lock refresh (lockFileMaintenance) — stays on the pinned nixpkgs
+  //     release branch (nixos-25.11) and just moves to its latest commit, i.e.
+  //     backported fixes/security patches. Safe, so it runs automatically.
+  //   * nixpkgs release jump (nixos-25.11 -> nixos-26.05) — edits flake.nix and
+  //     crosses a NixOS release, which is the breaking change. Gated behind the
+  //     dependency dashboard so it only opens when clicked, letting it ride with
+  //     a box major release instead of surprising operators.
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+
+  // Enable the nix manager (off by default). Lets Renovate read flake.nix inputs
+  // and maintain flake.lock.
+  nix: {
+    enabled: true,
+  },
+
+  // Weekly whole-lockfile refresh. This is the main win over Dependabot, which
+  // cannot update flake.lock at all. Automerges once CI (fmt/check + lint +
+  // tests) is green, since a within-release refresh is low risk.
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 6am on monday"],
+    automerge: true,
+  },
+
+  packageRules: [
+    {
+      // The only nix input pinned to a release branch in flake.nix. Bumping it
+      // is a breaking release jump, so hold it behind dashboard approval; the
+      // safe within-release patches still arrive via lockFileMaintenance above.
+      matchManagers: ["nix"],
+      matchDepNames: ["nixpkgs"],
+      dependencyDashboardApproval: true,
+    },
+  ],
+}


### PR DESCRIPTION
## What

Adds `.github/renovate.json5` to bring [Renovate](https://docs.renovatebot.com) to `coder/box`, with the Nix flake as the priority. Resolves the "investigate Dependabot" task: Dependabot can't touch `flake.lock`, Renovate can.

Closes #37.

## Behavior

- **`flake.lock` refreshed weekly** (`lockFileMaintenance`) — stays on the pinned `nixos-25.11` branch and moves to its latest commit (backported fixes/security patches). **Automerges** once CI (`fmt/check` + `lint` + tests) is green, since a within-release refresh is low risk.
- **nixpkgs release jump** (`nixos-25.11` → `nixos-26.05`) is **gated behind the dependency dashboard** — it only opens when clicked, so the breaking channel bump rides with a box major release instead of surprising operators.
- **`config:recommended`** enables the other default managers too (github-actions for workflow pins, terraform for `coderd/`) plus the dependency dashboard.

Validated with `renovate-config-validator --strict`.

## Requires (outside this repo)

Option A / hosted setup: the config stays inert until someone with org admin installs/enables the **Mend Renovate GitHub App** on `coder/box`. No self-hosted workflow or token is needed.

<details>
<summary>Design rationale</summary>

**Why not Dependabot:** it has no support for updating `flake.lock`, which is the whole point for a Nix flake repo.

**Why the split:** NixOS releases are `YY.MM` (~6 months apart) with no semver major/minor. Crossing a release (`25.11` → `26.05`) is the breaking event; within a release branch you only get backported fixes. Those two risk levels map cleanly onto Renovate's two nix mechanisms:

- `lockFileMaintenance` → refreshes the whole `flake.lock` within `nixos-25.11` (also disko / treefmt-nix / nixos-facter-modules, which track their default branches). Safe → automatic + automerge.
- nix manager input update → edits `flake.nix` to bump the nixpkgs branch ref. Breaking → gated behind dashboard approval.

**Why not `mkDefault` the nixpkgs version per host:** `nixpkgs.url` is a flake input, resolved and locked before the NixOS module system runs, so `mkDefault` in a host `local.nix` has no reach over it (that priority mechanism only applies to module options — e.g. `system.stateVersion`, which is a separate compat marker and shouldn't track the channel). Deployed hosts already freeze naturally: each box builds from its own `/etc/nixos-repo` checkout and only moves on `git pull && nixos-rebuild`. So the release jump is a deliberate action, which is why it's dashboard-gated to ride with a box major.

</details>

---
🤖 Generated with Coder Agents on behalf of @phorcys420.
