### PR TITLE
feat(configuration.nix): use Lix as the system Nix distribution

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -387,6 +387,11 @@ in
       gnomeExtensions.no-overview
     ];
 
+    # Use Lix (a drop-in Nix reimplementation) as the system Nix distribution
+    # instead of upstream CppNix. pkgs.lix comes from the pinned nixpkgs above,
+    # so this swaps the daemon, nixos-rebuild, and the `nix` CLI without adding
+    # a flake input or a from-source build.
+    nix.package = pkgs.lix;
     nix.settings.experimental-features = [
       "nix-command"
       "flakes"


### PR DESCRIPTION
Switch The Box from upstream CppNix to [Lix](https://lix.systems) as the system Nix distribution.

## What

```nix
nix.package = pkgs.lix;
```

Added next to the existing `nix.settings` block in `configuration.nix`. `pkgs.lix` (2.93.4) comes from the already-pinned nixpkgs 25.11, so the daemon, `nixos-rebuild`, and the `nix` CLI all run Lix. No new flake input, no `flake.lock` churn, no from-source build.

## Validation

Evaluated with Lix locally:

- `nixosConfigurations.*.config.nix.package` -> `lix 2.93.4`
- `make check` (flake eval, all systems) - pass
- `make fmt/check` + `make lint` - clean (0 changed)

## Scope note

This swaps the *system* Nix. It does not overlay nixpkgs, so packages that reference `pkgs.nix` in their closure still pull CppNix. If a full distribution swap is wanted, the follow-up options are:

- official `lix-project/nixos-module` (`nixosModules.lixFromNixpkgs` to avoid source builds), or
- a plain overlay: `nixpkgs.overlays = [ (f: p: { nix = p.lix; }) ]`

Happy to switch to either if preferred.

<details>
<summary>Decision log</summary>

- Goal: run Lix instead of vanilla Nix on the box.
- nixpkgs 25.11 (already pinned) ships `pkgs.lix` = 2.93.4, so no extra input or source build is needed.
- Chose `nix.package = pkgs.lix` over the official NixOS module because it is the smallest correct change, matches the box's reproducibility posture (everything from the pinned nixpkgs), and avoids ballooning ISO build times with a from-source Lix.
- Tradeoff: `pkgs.nix` consumers stay on CppNix. The module/overlay alternatives (noted above) cover that if desired.

</details>

---
_Opened by Coder Agents on behalf of @phorcys420._