### PR TITLE
refactor: use nixos-facter module from nixpkgs instead of flake input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ default `networking.hostName = "coder-box"` (set in `configuration.nix`).
 Two community tools do the heavy lifting:
 
 - [`disko`](https://github.com/nix-community/disko) declares partition layouts in Nix. `nixos/disko-standard.nix` is a single-disk UEFI layout (1 GB EFI / ZFS root pool; no on-disk swap — zram instead). `install.sh` picks the device at install time; the ZFS `networking.hostId` is derived in Nix from the hostname (sha256 substring), so each host gets a distinct id automatically. ZFS gives cheap on-demand snapshots (take one before a risky rebuild and roll back in seconds), zstd compression, and checksum/scrub integrity.
-- [`nixos-facter`](https://github.com/nix-community/nixos-facter) writes a JSON hardware report (`facter.json`) that replaces `hardware-configuration.nix` on new hosts. The `nixos-facter-modules` module reads it to set kernel modules, microcode, GPU drivers, and so on.
+- [`nixos-facter`](https://github.com/nix-community/nixos-facter) writes a JSON hardware report (`facter.json`) that replaces `hardware-configuration.nix` on new hosts. NixOS's built-in facter module (`hardware.facter`, shipped in nixpkgs) reads it to set kernel modules, microcode, GPU drivers, and so on.
 
 ## Installing on a new machine
 

--- a/agents.md
+++ b/agents.md
@@ -214,7 +214,7 @@ sudo k3s kubectl describe pod -n coder-workspaces <pod-name>
 ```
 /etc/nixos-repo/                # repo root (a Nix flake; sudo git required)
   flake.nix                     # entry point: nixosConfigurations.<host> per machine
-  flake.lock                    # pinned nixpkgs / disko / nixos-facter-modules
+  flake.lock                    # pinned nixpkgs / disko
   configuration.nix             # shared NixOS config (edit here for services/packages)
   local.nix.example             # template for hosts/<host>/local.nix
   nixos/

--- a/flake.lock
+++ b/flake.lock
@@ -20,21 +20,6 @@
         "type": "github"
       }
     },
-    "nixos-facter-modules": {
-      "locked": {
-        "lastModified": 1773858690,
-        "narHash": "sha256-oW0/lC0oRG5H5LaK6Rmh9L1wmkn9TbenM4bXwnIEDKA=",
-        "owner": "nix-community",
-        "repo": "nixos-facter-modules",
-        "rev": "139dcef4dfc97009629c445806f197883351ab4a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixos-facter-modules",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779467186,
@@ -54,7 +39,6 @@
     "root": {
       "inputs": {
         "disko": "disko",
-        "nixos-facter-modules": "nixos-facter-modules",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Hardware detection. `nixos-facter -o facter.json` on the target writes
-    # a JSON hardware report; nixos-facter-modules consumes it to set kernel
-    # modules, microcode, GPU drivers, etc. Replaces hardware-configuration.nix
-    # for common hardware.
-    nixos-facter-modules.url = "github:nix-community/nixos-facter-modules";
-
     # One-stop formatter/linter runner. Drives nixfmt + statix + deadnix (Nix)
     # and shfmt + shellcheck (shell) from a single config (./treefmt.nix), and
     # exposes both `nix fmt` (apply) and a `nix flake check` formatting check
@@ -37,7 +31,6 @@
       self,
       nixpkgs,
       disko,
-      nixos-facter-modules,
       treefmt-nix,
       ...
     }@inputs:
@@ -89,7 +82,12 @@
           modules = [
             ./configuration.nix
             disko.nixosModules.disko
-            nixos-facter-modules.nixosModules.facter
+            # nixos-facter's NixOS module ships in nixpkgs (hardware.facter.*)
+            # and is imported automatically, so no separate flake input is
+            # needed. Hosts point hardware.facter.reportPath at their
+            # facter.json to drive kernel modules, microcode, GPU drivers, etc.
+            # `nixos-facter -o facter.json` on the target generates the report;
+            # it replaces hardware-configuration.nix for common hardware.
             (./hosts + "/${hostname}")
           ]
           # Install hosts use their folder name as the hostname so


### PR DESCRIPTION
## What

The `nixos-facter` NixOS module was upstreamed into nixpkgs (`nixos/modules/hardware/facter`, registered in `module-list.nix`) and is now imported automatically. It exposes the same `hardware.facter.reportPath` option our hosts already set, so the `nixos-facter-modules` flake input is redundant.

This drops the input and its `mkHost` module import, relying on the nixpkgs-provided module instead. The `nixos-facter` CLI package was already sourced from nixpkgs, so it is unchanged.

## Changes

- `flake.nix`: remove `nixos-facter-modules` input, outputs arg, and the `nixosModules.facter` import.
- `flake.lock`: regenerated (input node removed).
- `README.md` / `agents.md`: update references.

## Validation

Ran in a `nixos/nix` container (nixos-25.11):

- `coder-thinkcentre` and all image hosts (`_appliance-iso`, `_appliance-disk`, `_installer-iso`) evaluate to a `toplevel` derivation, confirming `hardware.facter.reportPath` still resolves.
- `make fmt/check` and `make lint` (statix / deadnix / shellcheck) pass with 0 changes.

## Note

The nixpkgs module imports fewer submodules than the flake version did (covers disk, firmware, graphics, keyboard, networking, system, virtualisation; the flake version also had bluetooth, boot, camera, debug, fingerprint). `coder-thinkcentre` keeps `hardware-configuration.nix` as a backstop, so no functional regression there. Worth keeping in mind for any future disko-only host that relies purely on facter.

---
<sub>Opened by Coder Agents on behalf of @phorcys420.</sub>
