### PR TITLE
feat(configuration.nix): add nix-community cachix substituter

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -392,6 +392,14 @@ in
       "flakes"
     ];
     nix.settings.download-buffer-size = 268435456; # 256 MiB; quiets the "buffer full" warning on big closure pulls
+
+    # Extra binary cache: pull community-built closures (disko and other
+    # nix-community derivations) instead of building them locally. `extra-`
+    # appends to the defaults, so cache.nixos.org stays in place.
+    nix.settings.extra-substituters = [ "https://nix-community.cachix.org" ];
+    nix.settings.extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
     networking.firewall.enable = false;
 
     # ── PostgreSQL ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Add `nix-community.cachix.org` as an extra binary cache in the shared `nix.settings`.

```nix
nix.settings.extra-substituters = [ "https://nix-community.cachix.org" ];
nix.settings.extra-trusted-public-keys = [
  "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
];
```

## Why

Pull community-built closures (disko and other nix-community derivations) from a
binary cache instead of building them locally. `extra-` appends to the defaults,
so `cache.nixos.org` stays in place. Applies to every host via `configuration.nix`.

## Note

nixpkgs is pinned to the released `nixos-25.11` channel, so podman is already
served by `cache.nixos.org` and should not build from source. This cache mainly
helps with disko and other community derivations. If podman is genuinely
rebuilding, the cause is likely elsewhere (an overlay touching its deps, an
arch/unfree gap, or a stale substituter) and worth a separate look.

---
Drafted by Coder Agents on behalf of @phorcys420.
