### PR TITLE
ci: don't bake the checkout token into shipped images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
           # Empty for tag push (checks out the tag); honored for manual dispatch
           # to release an arbitrary commit.
           ref: ${{ github.event.inputs.ref }}
+          # This working tree is baked into the image at /etc/nixos-repo (via
+          # box-turnkey.nix's self.outPath). Don't persist the job token as an
+          # http.*.extraheader in .git/config, or the dead token ships in the
+          # image and makes `git pull` on installed boxes prompt for creds. The
+          # repo is public, so `git pull` on the box works anonymously.
+          persist-credentials: false
 
       # Install Nix natively + cache the /nix/store (shared with the test
       # workflow so releases build the exact same way).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,6 +170,14 @@ jobs:
           # Empty for push/PR (checks out the event ref); honored for manual
           # dispatch to build an arbitrary commit.
           ref: ${{ github.event.inputs.ref }}
+          # This working tree is baked into the image at /etc/nixos-repo (via
+          # box-turnkey.nix's self.outPath). actions/checkout defaults to
+          # persisting the job's short-lived token as an http.*.extraheader in
+          # .git/config; baked in, that dead token makes `git pull` on installed
+          # boxes prompt for credentials. Don't persist it (the repo is public;
+          # the initial fetch still authenticates, and `git pull` on the box
+          # works anonymously).
+          persist-credentials: false
 
       # Install Nix natively + cache the /nix/store (shared with the release
       # workflow so both build images the exact same way).


### PR DESCRIPTION
## What

Stop baking the CI checkout token into shipped images, so `git pull` on installed boxes works without a credential prompt.

## The bug

On an installed box, `git pull` in `/etc/nixos-repo` prompts for a GitHub username while a fresh `git clone` of the same public repo works anonymously:

```
[root@coder-box:/etc/nixos-repo]# git config --local --get-regexp 'http\..*\.extraheader'
http.https://github.com/.extraheader=AUTHORIZATION: basic <base64 x-access-token:ghs_…>
Username for 'https://github.com':
```

## Root cause

`actions/checkout` defaults to `persist-credentials: true`, which writes the job's short-lived token into `.git/config` as `http.https://github.com/.extraheader`. `box-turnkey.nix` bakes the working tree into the image at `/etc/nixos-repo` via `self.outPath` (which includes `.git` on the dirty CI build), so that token ships in every installer/appliance image and lands on installed boxes. The token expired ~1h after the build, so on the box `git pull` sends a dead credential → GitHub `401` → git prompts for a username. A fresh `git clone` has no such header and fetches anonymously, which is why clone works but pull doesn't.

## Fix

Set `persist-credentials: false` on the two checkouts whose tree gets baked into an image:

- `test.yml` → `Images` job
- `release.yml` → `build` job

The `.git` directory and `origin` are still shipped, so `git pull` keeps working — just anonymously, which is fine for a public repo. The initial CI fetch still authenticates; nothing downstream relies on the persisted credential (no workflow pushes via git, and the release publishes through `softprops/action-gh-release` using `GITHUB_TOKEN`). Nix fetches flake inputs with its own fetcher, unaffected.

## Validation

- `actionlint` clean on both workflows; YAML parses.

## Existing boxes

Images built before this merges still carry the dead token. On an affected box, drop it once:

```sh
git -C /etc/nixos-repo config --local --unset-all http.https://github.com/.extraheader
```

New images built after this won't have it.

---
_Generated by Coder Agents on behalf of @phorcys420._
